### PR TITLE
WIP: Bounty

### DIFF
--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -9,9 +9,7 @@ import './PullPayment.sol';
  */
 
 contract Target {
-  function checkInvarient() returns(bool){
-    return true;
-  }
+  function checkInvarient() returns(bool);
 }
 
 contract Bounty is PullPayment {
@@ -23,8 +21,8 @@ contract Bounty is PullPayment {
     if (claimed) throw;
   }
 
-  function createTarget() returns(Target) {
-    target = new Target();
+  function createTarget(address targetAddress) returns(Target) {
+    target = Target(targetAddress);
     researchers[target] = msg.sender;
     return target;
   }
@@ -37,7 +35,6 @@ contract Bounty is PullPayment {
     address researcher = researchers[target];
     if (researcher == 0) throw;
     // Check Target contract invariants
-    // Customize this to the specifics of your contract
     if (!target.checkInvarient()) {
       throw;
     }

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -23,6 +23,10 @@ contract Bounty is PullPayment {
     return target;
   }
 
+  function checkInvarient() returns(bool){
+    return true;
+  }
+
   function claim(SimpleToken target) {
     address researcher = researchers[target];
     if (researcher == 0) throw;

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -1,15 +1,21 @@
 pragma solidity ^0.4.0;
 import './PullPayment.sol';
-import './token/SimpleToken.sol';
 
 /*
  * Bounty
  * This bounty will pay out if you can cause a SimpleToken's balance
- * to be lower than its totalSupply, which would mean that it doesn't 
+ * to be lower than its totalSupply, which would mean that it doesn't
  * have sufficient ether for everyone to withdraw.
  */
-contract Bounty is PullPayment {
 
+contract Target {
+  function checkInvarient() returns(bool){
+    return true;
+  }
+}
+
+contract Bounty is PullPayment {
+  Target target;
   bool public claimed;
   mapping(address => address) public researchers;
 
@@ -17,22 +23,22 @@ contract Bounty is PullPayment {
     if (claimed) throw;
   }
 
-  function createTarget() returns(SimpleToken) {
-    SimpleToken target = new SimpleToken();
+  function createTarget() returns(Target) {
+    target = new Target();
     researchers[target] = msg.sender;
     return target;
   }
 
   function checkInvarient() returns(bool){
-    return true;
+    return target.checkInvarient();
   }
 
-  function claim(SimpleToken target) {
+  function claim(Target target) {
     address researcher = researchers[target];
     if (researcher == 0) throw;
-    // Check SimpleToken contract invariants
+    // Check Target contract invariants
     // Customize this to the specifics of your contract
-    if (target.totalSupply() == target.balance) {
+    if (!target.checkInvarient()) {
       throw;
     }
     asyncSend(researcher, this.balance);

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -9,7 +9,7 @@ import './PullPayment.sol';
  */
 
 contract Target {
-  function checkInvarient() returns(bool);
+  function checkInvariant() returns(bool);
 }
 
 contract Bounty is PullPayment {
@@ -27,15 +27,15 @@ contract Bounty is PullPayment {
     return target;
   }
 
-  function checkInvarient() returns(bool){
-    return target.checkInvarient();
+  function checkInvariant() returns(bool){
+    return target.checkInvariant();
   }
 
   function claim(Target target) {
     address researcher = researchers[target];
     if (researcher == 0) throw;
     // Check Target contract invariants
-    if (!target.checkInvarient()) {
+    if (!target.checkInvariant()) {
       throw;
     }
     asyncSend(researcher, this.balance);

--- a/contracts/test-helpers/InsecureTargetMock.sol
+++ b/contracts/test-helpers/InsecureTargetMock.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.0;
+
+contract InsecureTargetMock {
+  function checkInvarient() returns(bool){
+    return false;
+  }
+}

--- a/contracts/test-helpers/InsecureTargetMock.sol
+++ b/contracts/test-helpers/InsecureTargetMock.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.0;
 
 contract InsecureTargetMock {
-  function checkInvarient() returns(bool){
+  function checkInvariant() returns(bool){
     return false;
   }
 }

--- a/contracts/test-helpers/SecureTargetMock.sol
+++ b/contracts/test-helpers/SecureTargetMock.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.0;
+
+contract SecureTargetMock {
+  function checkInvarient() returns(bool){
+    return true;
+  }
+}

--- a/contracts/test-helpers/SecureTargetMock.sol
+++ b/contracts/test-helpers/SecureTargetMock.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.0;
 
 contract SecureTargetMock {
-  function checkInvarient() returns(bool){
+  function checkInvariant() returns(bool){
     return true;
   }
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,4 +5,6 @@ module.exports = function(deployer) {
   deployer.deploy(Bounty);
   deployer.deploy(Ownable);
   deployer.deploy(LimitFunds);
+  deployer.deploy(SecureTargetMock);
+  deployer.deploy(InsecureTargetMock);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,6 +5,8 @@ module.exports = function(deployer) {
   deployer.deploy(Bounty);
   deployer.deploy(Ownable);
   deployer.deploy(LimitFunds);
-  deployer.deploy(SecureTargetMock);
-  deployer.deploy(InsecureTargetMock);
+  if(deployer.network == 'test'){
+    deployer.deploy(SecureTargetMock);
+    deployer.deploy(InsecureTargetMock);
+  };
 };

--- a/test/Bounty.js
+++ b/test/Bounty.js
@@ -1,13 +1,26 @@
 contract('Bounty', function(accounts) {
-  it.only("create target", function(done){
+  it.only("can call checkInvarient for InsecureTargetMock", function(done){
     var bounty = Bounty.deployed();
-
-    bounty.createTarget().
+    var target = SecureTargetMock.deployed();
+    bounty.createTarget(target.address).
       then(function() {
         return bounty.checkInvarient.call()
       }).
       then(function(result) {
         assert.isTrue(result);
+      }).
+      then(done);
+  })
+
+  it("can call checkInvarient for InsecureTargetMock", function(done){
+    var bounty = Bounty.deployed();
+    var target = InsecureTargetMock.deployed();
+    bounty.createTarget(target.address).
+      then(function() {
+        return bounty.checkInvarient.call()
+      }).
+      then(function(result) {
+        assert.isFalse(result);
       }).
       then(done);
   })

--- a/test/Bounty.js
+++ b/test/Bounty.js
@@ -1,10 +1,10 @@
 contract('Bounty', function(accounts) {
-  it("can call checkInvarient for InsecureTargetMock", function(done){
+  it("can call checkInvariant for InsecureTargetMock", function(done){
     var bounty = Bounty.deployed();
     var target = SecureTargetMock.deployed();
     bounty.createTarget(target.address).
       then(function() {
-        return bounty.checkInvarient.call()
+        return bounty.checkInvariant.call()
       }).
       then(function(result) {
         assert.isTrue(result);
@@ -12,12 +12,12 @@ contract('Bounty', function(accounts) {
       then(done);
   })
 
-  it("can call checkInvarient for InsecureTargetMock", function(done){
+  it("can call checkInvariant for InsecureTargetMock", function(done){
     var bounty = Bounty.deployed();
     var target = InsecureTargetMock.deployed();
     bounty.createTarget(target.address).
       then(function() {
-        return bounty.checkInvarient.call()
+        return bounty.checkInvariant.call()
       }).
       then(function(result) {
         assert.isFalse(result);

--- a/test/Bounty.js
+++ b/test/Bounty.js
@@ -1,5 +1,5 @@
 contract('Bounty', function(accounts) {
-  it.only("can call checkInvarient for InsecureTargetMock", function(done){
+  it("can call checkInvarient for InsecureTargetMock", function(done){
     var bounty = Bounty.deployed();
     var target = SecureTargetMock.deployed();
     bounty.createTarget(target.address).

--- a/test/Bounty.js
+++ b/test/Bounty.js
@@ -1,0 +1,14 @@
+contract('Bounty', function(accounts) {
+  it.only("create target", function(done){
+    var bounty = Bounty.deployed();
+
+    bounty.createTarget().
+      then(function() {
+        return bounty.checkInvarient.call()
+      }).
+      then(function(result) {
+        assert.isTrue(result);
+      }).
+      then(done);
+  })
+});


### PR DESCRIPTION
This Bounty contract has no knowledge of target contract so the user does not have to modify the contract.

However, the current implementation let anyone to create any target contract so one can put a dummy contract. To make this contract production ready, the following has to be done.

- Restrict `createContract` to be only executable by a contract owner.
- At deployment phase, let the contract owner to either pass the real address of the target contract, or create a clone of the contract manually and pass that address.
- Since there is no way to have a separate contract per researcher, modify the code to allow researchers to work against the same contract.

