### PR TITLE
add check prevening ownables from getting stuck

### DIFF
--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -17,7 +17,7 @@ contract Ownable {
   }
 
   function transfer(address newOwner) onlyOwner {
-    owner = newOwner;
+    if (newOwner != address(0)) owner = newOwner;
   }
 
 }

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -34,4 +34,20 @@ contract('Ownable', function(accounts) {
       .then(done)
   });
 
+  it("should guard ownership against stuck state" ,function(done) {
+    var ownable = Ownable.deployed();
+
+    return ownable.owner()
+      .then(function (originalOwner) {
+        return ownable.transfer(null, {from: originalOwner})
+          .then(function() {
+            return ownable.owner();
+          })
+          .then(function(newOwner) {
+            assert.equal(originalOwner, newOwner);
+          })
+          .then(done);
+      });
+  });
+
 });


### PR DESCRIPTION
Presently, an Ownable contract can enter a stuck state by sending in no parameters to `transfer`, or passing a mistyped variable. It is probably a rare scenario, but since it isn't possible to recover from such a mistake, it seems to me like it should be guarded against.

I understand the need to allow contracts to be burned but it seems like that action should never unintentionally arise. Another burn account could be designated instead, like `sha3(sha3(0))` or one of the precompile addresses.