### PR TITLE
Move away from migration fixtures in tests

### DIFF
--- a/test/Claimable.js
+++ b/test/Claimable.js
@@ -1,7 +1,13 @@
 contract('Claimable', function(accounts) {
+  var claimable;
+
+  beforeEach(function() {
+    return Claimable.new().then(function(deployed) {
+      claimable = deployed;
+    });
+  });
 
   it("should have an owner", function(done) {
-    var claimable = Claimable.deployed();
     return claimable.owner()
       .then(function(owner) {
         assert.isTrue(owner != 0);
@@ -10,19 +16,18 @@ contract('Claimable', function(accounts) {
   });
 
   it("changes pendingOwner after transfer", function(done) {
-    var claimable = Claimable.deployed();
-    return claimable.transfer(accounts[1])
+    var newOwner = accounts[1];
+    return claimable.transfer(newOwner)
       .then(function() {
         return claimable.pendingOwner();
       })
       .then(function(pendingOwner) {
-        assert.isTrue(pendingOwner === accounts[1]);
+        assert.isTrue(pendingOwner === newOwner);
       })
       .then(done)
   });
 
   it("should prevent to claimOwnership from no pendingOwner", function(done) {
-    var claimable = Claimable.deployed();
     return claimable.claimOwnership({from: accounts[2]})
       .then(function() {
         return claimable.owner();
@@ -33,20 +38,7 @@ contract('Claimable', function(accounts) {
       .then(done)
   });
 
-  it("changes allow pending owner to claim ownership", function(done) {
-    var claimable = Claimable.deployed();
-    return claimable.claimOwnership({from: accounts[1]})
-      .then(function() {
-        return claimable.owner();
-      })
-      .then(function(owner) {
-        assert.isTrue(owner === accounts[1]);
-      })
-      .then(done)
-  });
-
   it("should prevent non-owners from transfering" ,function(done) {
-    var claimable = Claimable.deployed();
     return claimable.transfer(accounts[2], {from: accounts[2]})
       .then(function() {
         return claimable.pendingOwner();
@@ -57,4 +49,23 @@ contract('Claimable', function(accounts) {
       .then(done)
   });
 
+  describe("after initiating a transfer", function () {
+    var newOwner;
+
+    beforeEach(function () {
+      newOwner = accounts[1];
+      return claimable.transfer(newOwner);
+    });
+
+    it("changes allow pending owner to claim ownership", function(done) {
+      return claimable.claimOwnership({from: newOwner})
+        .then(function() {
+          return claimable.owner();
+        })
+        .then(function(owner) {
+          assert.isTrue(owner === newOwner);
+        })
+        .then(done)
+    });
+  });
 });

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -1,6 +1,13 @@
 contract('Ownable', function(accounts) {
+  var ownable;
+
+  beforeEach(function() {
+    return Ownable.new().then(function(deployed) {
+      ownable = deployed;
+    });
+  });
+
   it("should have an owner", function(done) {
-    var ownable = Ownable.deployed();
     return ownable.owner()
       .then(function(owner) {
         assert.isTrue(owner != 0);
@@ -9,7 +16,6 @@ contract('Ownable', function(accounts) {
   });
 
   it("changes owner after transfer", function(done) {
-    var ownable = Ownable.deployed();
     var other = accounts[1];
     return ownable.transfer(other)
       .then(function() {
@@ -22,7 +28,6 @@ contract('Ownable', function(accounts) {
   });
 
   it("should prevent non-owners from transfering" ,function(done) {
-    var ownable = Ownable.deployed();
     var other = accounts[2];
     return ownable.transfer(other, {from: accounts[2]})
       .then(function() {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/zeppelin-solidity/issues/55. Those were all the tests I saw still using that pattern, let me know if I missed any.

I can change the set up in the `beforeEach` if needed. I personally like that style, because it removes a lot of the redundant set up logic, allowing for the logic under test to be more clear.