### PR TITLE
fix truffle build

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,14 +1,4 @@
 module.exports = {
-  build: {
-    "index.html": "index.html",
-    "app.js": [
-      "javascripts/app.js"
-    ],
-    "app.css": [
-      "stylesheets/app.css"
-    ],
-    "images/": "images/"
-  },
   rpc: {
     host: "localhost",
     port: 8545


### PR DESCRIPTION
Running `truffle build` produces an error. This fixes that. Since zeppelin has no front-end, we don't need to build a dapp.