### PR TITLE
fixes gh-99 PullPaymentMock needed a payable constructor

### DIFF
--- a/contracts/test-helpers/PullPaymentMock.sol
+++ b/contracts/test-helpers/PullPaymentMock.sol
@@ -3,6 +3,9 @@ import '../PullPayment.sol';
 
 // mock class using PullPayment
 contract PullPaymentMock is PullPayment {
+
+  function PullPaymentMock() payable { }
+
   // test helper function to call asyncSend
   function callSend(address dest, uint amount) {
     asyncSend(dest, amount);

--- a/contracts/test-helpers/PullPaymentMock.sol
+++ b/contracts/test-helpers/PullPaymentMock.sol
@@ -7,9 +7,6 @@ contract PullPaymentMock is PullPayment {
   function PullPaymentMock() payable { }
 
   // test helper function to call asyncSend
-
-  function PullPaymentMock() payable { }
-
   function callSend(address dest, uint amount) {
     asyncSend(dest, amount);
   }


### PR DESCRIPTION
Added payable to the PullPaymentMock constructor, which is necessary to receive the x-amount of ether needed in the tests. This fixes the travis build.