### PR TITLE
Make test cases that use assertJump fail if they dont fail

### DIFF
--- a/test/BasicToken.js
+++ b/test/BasicToken.js
@@ -25,8 +25,9 @@ contract('BasicToken', function(accounts) {
     try {
       let transfer = await token.transfer(accounts[1], 101);
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
 });

--- a/test/LimitBalance.js
+++ b/test/LimitBalance.js
@@ -26,8 +26,9 @@ contract('LimitBalance', function(accounts) {
     try {
       let limDeposit = await lb.limitedDeposit({value: amount});
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
   it("should allow multiple sends below limit", async function() {
@@ -49,8 +50,9 @@ contract('LimitBalance', function(accounts) {
     try {
       await lb.limitedDeposit({value: amount+1})
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
 });

--- a/test/SafeMath.js
+++ b/test/SafeMath.js
@@ -40,8 +40,9 @@ contract('SafeMath', function(accounts) {
     try {
       let subtract = await safeMath.subtract(a, b);
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
   it("should throw an error on addition overflow", async function() {
@@ -50,8 +51,9 @@ contract('SafeMath', function(accounts) {
     try {
       let add = await safeMath.add(a, b);
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
   it("should throw an error on multiplication overflow", async function() {
@@ -60,8 +62,9 @@ contract('SafeMath', function(accounts) {
     try {
       let multiply = await safeMath.multiply(a, b);
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
 });

--- a/test/StandardToken.js
+++ b/test/StandardToken.js
@@ -32,8 +32,9 @@ contract('StandardToken', function(accounts) {
     try {
       let transfer = await token.transfer(accounts[1], 101);
     } catch(error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
   it("should return correct balances after transfering from another account", async function() {
@@ -57,8 +58,9 @@ contract('StandardToken', function(accounts) {
     try {
       let transfer = await token.transferFrom(accounts[0], accounts[2], 100, {from: accounts[1]});
     } catch (error) {
-      assertJump(error);
+      return assertJump(error);
     }
+    assert.fail('should have thrown before');
   });
 
 });


### PR DESCRIPTION
Am I'm not sure if missing something (as I'm fairly new to TDD), but I think that with the current assertJump the case in which the function doesn't throw and just works, makes the test case to not have any assertions and therefore pass. 

Problem with this is that the test won't catch when a function that should have throw starts to work. 
