### PR TITLE
BasicToken.sol: Remove useless check

### DIFF
--- a/contracts/token/BasicToken.sol
+++ b/contracts/token/BasicToken.sol
@@ -14,9 +14,6 @@ contract BasicToken is ERC20Basic, SafeMath {
   mapping(address => uint) balances;
 
   function transfer(address _to, uint _value) {
-    if (balances[msg.sender] < _value) {
-      throw;
-    } 
     balances[msg.sender] = safeSub(balances[msg.sender], _value);
     balances[_to] = safeAdd(balances[_to], _value);
     Transfer(msg.sender, _to, _value);


### PR DESCRIPTION
The condition this commit removes is already implemented by the call to `safeSub`