### PR TITLE
Add clarifying comment to standard token transfer from function

### DIFF
--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -26,7 +26,10 @@ contract StandardToken is ERC20, SafeMath {
 
   function transferFrom(address _from, address _to, uint _value) returns (bool success) {
     var _allowance = allowed[_from][msg.sender];
-    
+
+    // Check is not needed because safeSub(_allowance, _value) will already throw if this condition is not met
+    // if (_value > _allowance) throw;
+
     balances[_to] = safeAdd(balances[_to], _value);
     balances[_from] = safeSub(balances[_from], _value);
     allowed[_from][msg.sender] = safeSub(_allowance, _value);


### PR DESCRIPTION
Someone was confused in Slack about why in StandardToken transferFrom it isn't checked whether the transferring value is greater than the allowance. AFAIK, this same check is performed in SafeMath.safeSub.

I agree and think it is wasteful to perform the same computation twice on the EVM, but some more clarity for a casual reader of the contract is needed.
