### PR TITLE
[VestedToken] Check if tokens can be transferred on transferFrom

### DIFF
--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -15,6 +15,19 @@ contract VestedToken is StandardToken {
 
   mapping (address => TokenGrant[]) public grants;
 
+  modifier canTransfer(uint _value) {
+    if (_value > transferableTokens(msg.sender, uint64(now))) throw;
+    _;
+  }
+
+  function transfer(address _to, uint _value) canTransfer(_value) returns (bool success) {
+    return super.transfer(_to, _value);
+  }
+
+  function approve(address _spender, uint _value) canTransfer(_value) returns (bool success) {
+    return super.approve(_spender, _value);
+  }
+
   function grantVestedTokens(
     address _to,
     uint256 _value,
@@ -125,13 +138,5 @@ contract VestedToken is StandardToken {
     }
 
     return safeSub(balances[holder], nonVested);
-  }
-
-  function transfer(address _to, uint _value) returns (bool success) {
-    if (_value > transferableTokens(msg.sender, uint64(now))) {
-      throw;
-    }
-
-    return super.transfer(_to, _value);
   }
 }

--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -15,17 +15,17 @@ contract VestedToken is StandardToken {
 
   mapping (address => TokenGrant[]) public grants;
 
-  modifier canTransfer(uint _value) {
-    if (_value > transferableTokens(msg.sender, uint64(now))) throw;
+  modifier canTransfer(address _sender, uint _value) {
+    if (_value > transferableTokens(_sender, uint64(now))) throw;
     _;
   }
 
-  function transfer(address _to, uint _value) canTransfer(_value) returns (bool success) {
+  function transfer(address _to, uint _value) canTransfer(msg.sender, _value) returns (bool success) {
     return super.transfer(_to, _value);
   }
 
-  function approve(address _spender, uint _value) canTransfer(_value) returns (bool success) {
-    return super.approve(_spender, _value);
+  function transferFrom(address _from, address _to, uint _value) canTransfer(_from, _value) returns (bool success) {
+    return super.transferFrom(_from, _to, _value);
   }
 
   function grantVestedTokens(

--- a/test/VestedToken.js
+++ b/test/VestedToken.js
@@ -52,6 +52,16 @@ contract('VestedToken', function(accounts) {
       assert.fail('should have thrown before');
     })
 
+    it('throws when trying to transfer from non vested tokens', async () => {
+      try {
+        await token.approve(accounts[7], 1, { from: receiver })
+        await token.transferFrom(receiver, accounts[7], tokenAmount, { from: accounts[7] })
+      } catch(error) {
+        return assertJump(error);
+      }
+      assert.fail('should have thrown before');
+    })
+
     it('can be revoked by granter', async () => {
       await token.revokeTokenGrant(receiver, 0, { from: granter });
       assert.equal(await token.balanceOf(receiver), 0);
@@ -76,6 +86,13 @@ contract('VestedToken', function(accounts) {
     it('can transfer all tokens after vesting ends', async () => {
       await timer(vesting + 1);
       await token.transfer(accounts[7], tokenAmount, { from: receiver })
+      assert.equal(await token.balanceOf(accounts[7]), tokenAmount);
+    })
+
+    it('can approve and transferFrom all tokens after vesting ends', async () => {
+      await timer(vesting + 1);
+      await token.approve(accounts[7], tokenAmount, { from: receiver })
+      await token.transferFrom(receiver, accounts[7], tokenAmount, { from: accounts[7] })
       assert.equal(await token.balanceOf(accounts[7]), tokenAmount);
     })
   })


### PR DESCRIPTION
While becoming more familiar with the idea of approve and transferFrom I have just realized that the current implementation of VestedToken was broken and one could bypass the vesting calendar transferring tokens using approve and transferFrom as the amount of transferrableTokens wasn't checked. 

This is pretty bad as someone can do approve(myself, tokens) and then transferFrom(myself, otherAccount, tokens) and all tokens will be transferred regardless of the grant.

I have been doing some mainnet exploring before posting this, and AFAIK it doesn't look like anyone had deployed it yet. I might be wrong, so if you know anyone running it in production, urge them to revoke all token grants and migrate the contract ASAP. 