### PR TITLE
Decouple transferable logic from VestedToken

### DIFF
--- a/contracts/token/TransferableToken.sol
+++ b/contracts/token/TransferableToken.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.8;
+
+import "./ERC20.sol";
+
+contract TransferableToken is ERC20 {
+  modifier canTransfer(address _sender, uint _value) {
+   if (_value > transferableTokens(_sender, uint64(now))) throw;
+   _;
+  }
+
+  function transfer(address _to, uint _value) canTransfer(msg.sender, _value) returns (bool success) {
+   return super.transfer(_to, _value);
+  }
+
+  function transferFrom(address _from, address _to, uint _value) canTransfer(_from, _value) returns (bool success) {
+   return super.transferFrom(_from, _to, _value);
+  }
+
+  function transferableTokens(address holder, uint64 time) constant public returns (uint256) {
+    return balanceOf(holder);
+  }
+}


### PR DESCRIPTION
This PR decouples VestedToken transferable logic into another contract that is meant to be used as a base class for other contracts. 

This is needed for composing multiple transferable factors in a clean way.

For example in Aragon we have our main `Stock` contract be something like:

```
contract Stock is GovernanceToken, VestedToken {}
```

Where `GovernanceToken` also limits token transferability based on whether a holder has voted on an opened proposal, and therefore her tokens locked.

This allows for recursively finding what is the maximum amount of tokens that can be transferred at any given moment. Helpful reference on inheritance can be found on the Solidity [doc](http://solidity.readthedocs.io/en/develop/contracts.html#inheritance), but basically it will call the function on the right most contract and then if `super` is called it will jump to the next one on the left until it gets to the base class, in this case the new `TransferableToken` implementation that just returns the holder balance. 