### PR TITLE
Change sha3 and suicide methods to keccak256 and selfdestruct respectively

### DIFF
--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -25,8 +25,8 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
     DayLimit(_daylimit) { }
 
   // kills the contract sending everything to `_to`.
-  function kill(address _to) onlymanyowners(sha3(msg.data)) external {
-    suicide(_to);
+  function kill(address _to) onlymanyowners(keccak256(msg.data)) external {
+    selfdestruct(_to);
   }
 
   // gets called when no other function matches
@@ -51,7 +51,7 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
       return 0;
     }
     // determine our operation hash.
-    _r = sha3(msg.data, block.number);
+    _r = keccak256(msg.data, block.number);
     if (!confirm(_r) && txs[_r].to == 0) {
       txs[_r].to = _to;
       txs[_r].value = _value;
@@ -73,11 +73,11 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
     }
   }
 
-  function setDailyLimit(uint _newLimit) onlymanyowners(sha3(msg.data)) external {
+  function setDailyLimit(uint _newLimit) onlymanyowners(keccak256(msg.data)) external {
     _setDailyLimit(_newLimit);
   }
 
-  function resetSpentToday() onlymanyowners(sha3(msg.data)) external {
+  function resetSpentToday() onlymanyowners(keccak256(msg.data)) external {
     _resetSpentToday();
   }
 


### PR DESCRIPTION
`sha3` has been aliased to `keccak256` (see ethereum/EIPs#59 for rationale and discussion).

Along with `suicide` they're planned to be retired on the next breaking release (ethereum/solidity#1476).