### PR TITLE
Create and test MintableToken contract

### DIFF
--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.8;
+
+
+import './StandardToken.sol';
+import '../ownership/Ownable.sol';
+
+
+
+/**
+ * Mintable token
+ *
+ * Simple ERC20 Token example, with mintable token creation
+ * Issue:
+ * https://github.com/OpenZeppelin/zeppelin-solidity/issues/120
+ * Based on code by TokenMarketNet:
+ * https://github.com/TokenMarketNet/ico/blob/master/contracts/MintableToken.sol
+ */
+
+contract MintableToken is StandardToken, Ownable {
+  event Mint(address indexed to, uint value);
+
+  bool public mintingFinished = false;
+  uint public totalSupply = 0;
+
+  modifier canMint() {
+    if(mintingFinished) throw;
+    _;
+  }
+
+  function mint(address _to, uint _amount) onlyOwner canMint returns (bool) {
+    totalSupply = safeAdd(totalSupply, _amount);
+    balances[_to] = safeAdd(balances[_to], _amount);
+    Mint(_to, _amount);
+    return true;
+  }
+
+  function finishMinting() onlyOwner returns (bool) {
+    mintingFinished = true;
+    return true;
+  }
+}

--- a/test/MintableToken.js
+++ b/test/MintableToken.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assertJump = require('./helpers/assertJump');
+var MintableToken = artifacts.require('../contracts/Tokens/MintableToken.sol');
+
+contract('Mintable', function(accounts) {
+  let token;
+
+  beforeEach(async function() {
+    token = await MintableToken.new();
+  });
+
+  it('should start with a totalSupply of 0', async function() {
+    let totalSupply = await token.totalSupply();
+
+    assert.equal(totalSupply, 0);
+  });
+
+  it('should return mintingFinished false after construction', async function() {
+    let mintingFinished = await token.mintingFinished();
+
+    assert.equal(mintingFinished, false);
+  });
+
+  it('should mint a given amount of tokens to a given address', async function() {
+    await token.mint(accounts[0], 100);
+    
+    let balance0 = await token.balanceOf(accounts[0]);
+    assert(balance0, 100);
+    
+    let totalSupply = await token.totalSupply();
+    assert(totalSupply, 100);
+  })
+
+});


### PR DESCRIPTION
Creates MintableToken contract that inherits from the StandardTokenContract.
MintableToken has an owner who is able to:

1) Mint tokens to a given account
2) Finish minting to let relevant parties know that minting is complete
3) Recover tokens from a given account

This contract was created in response to issue #120 
It's fully tested in MintableToken.js and all tests are passing.