### PR TITLE
Remove excessive condition from SafeMath.safeAdd()

### DIFF
--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -25,7 +25,7 @@ contract SafeMath {
 
   function safeAdd(uint a, uint b) internal returns (uint) {
     uint c = a + b;
-    assert(c>=a && c>=b);
+    assert(c >= a);
     return c;
   }
 


### PR DESCRIPTION
There is no situation when `c>=a` will be `true` while `c>=b` will be `false`.