### PR TITLE
Add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules/
 build/
 .DS_Store/
+/coverage
+coverage.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "scripts/test.sh",
     "console": "truffle console",
-    "install": "scripts/install.sh"
+    "install": "scripts/install.sh",
+    "coverage": "scripts/coverage.sh"
   },
   "repository": {
     "type": "git",
@@ -35,6 +36,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.23.0",
     "ethereumjs-testrpc": "^3.0.2",
+    "solidity-coverage": "^0.1.0",
     "truffle": "https://github.com/ConsenSys/truffle.git#3.1.9"
   }
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+SOLIDITY_COVERAGE=true ./node_modules/.bin/solidity-coverage

--- a/truffle.js
+++ b/truffle.js
@@ -1,10 +1,13 @@
 require('babel-register');
 require('babel-polyfill');
 
+var provider;
 var HDWalletProvider = require('truffle-hdwallet-provider');
-
 var mnemonic = '[REDACTED]';
-var provider = new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/');
+
+if (!process.env.SOLIDITY_COVERAGE){
+  provider = new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/')
+}
 
 
 module.exports = {
@@ -17,6 +20,13 @@ module.exports = {
     ropsten: {
       provider: provider,
       network_id: 3 // official id of the ropsten network
+    },
+    coverage: {
+      host: "localhost",
+      network_id: "*", 
+      port: 8555,         
+      gas: 0xfffffffffff, 
+      gasPrice: 0x01      
     }
   }
 };


### PR DESCRIPTION
This PR addresses #107.
+ Adds coverage for Zeppelin contracts using [solidity-coverage](https://github.com/sc-forks/solidity-coverage) (a Solcover fork). 
+ Adds npm convenience script to generate reports: `npm run coverage`
+ Modifies `.gitignore` to include coverage artifacts
+ Modifies `truffle.js` by relocating the HDWalletProvider call to the `ropsten` network declaration. Not sure why, but the current setup (where the provider is declared at the top of the file) resulted in non-deterministic failures of Truffle's connection to `solidity-coverage's` custom testrpc . While debugging this issue, I ran `lsof -i` to find out what ports were open could see  that a connection is always established on AWS with Infura, regardless of what network flag Truffle is run with. Putting the Provider call within the config is consistent with [HDWalletProvider's usage instructions](https://github.com/trufflesuite/truffle-hdwallet-provider#truffle-usage) but I don't know if that alters Zeppelin's intent here or not.  
+ [Sample HTML report for Zeppelin at commit 726593c0a21e866ca80a38189abe3e76ed171dc8](https://cgewecke.github.io/ozep-cvrg-pr/) 

Note: On my machine Truffle takes about 45s to begin executing the instrumented tests after compiling them - I think they're just huge. The utility will seem to hang but eventually all tests pass and you should see:


![reports_ss](https://cloud.githubusercontent.com/assets/7332026/26067071/cbe3392a-394d-11e7-841b-21a5bd5d00f7.png)

Please let me know if you run into problems or find discrepancies between the reports and your tests' actual behavior. Would love to help out with this. Thanks! 



