### PR TITLE
[SafeMath] Remove unnecessary checks from safeDiv

### DIFF
--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -12,9 +12,9 @@ library SafeMath {
   }
 
   function div(uint a, uint b) internal returns (uint) {
-    assert(b > 0);
+    // assert(b > 0); // Solidity automatically throws when dividing by 0
     uint c = a / b;
-    assert(a == b * c + a % b);
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 


### PR DESCRIPTION
Solidity already checks whether the divisor is 0 and throws if so.

Also removes the division proof which, AFAIK, there is no edge case in which it would not hold or overflow.