### PR TITLE
Edit natspec documentation typos

### DIFF
--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -44,7 +44,7 @@ contract Bounty is PullPayment, Destructible {
 
   /**
    * @dev Sends the contract funds to the researcher that proved the contract is broken.
-   * @param Target contract
+   * @param target contract
    */
   function claim(Target target) {
     address researcher = researchers[target];

--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -101,7 +101,6 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
 
   /** 
    * @dev Resets the value spent to enable more spending
-   * @param _newLimit 
    */
   function resetSpentToday() onlymanyowners(keccak256(msg.data)) external {
     _resetSpentToday();

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -17,8 +17,8 @@ contract DelayedClaimable is Claimable {
   /**
    * @dev Used to specify the time period during which a pending 
    * owner can claim ownership. 
-   * @params _start The earliest time ownership can be claimed.
-   * @params _end The latest time ownership can be claimed. 
+   * @param _start The earliest time ownership can be claimed.
+   * @param _end The latest time ownership can be claimed. 
    */
   function setLimits(uint _start, uint _end) onlyOwner {
     if (_start > _end)

--- a/contracts/ownership/Shareable.sol
+++ b/contracts/ownership/Shareable.sol
@@ -58,7 +58,6 @@ contract Shareable {
    * transactions as well as the selection of addresses capable of confirming them.
    * @param _owners A list of owners.
    * @param _required The amount required for a transaction to be approved.
-   * @param _limit Uint to represent the daily limit.
    */
   function Shareable(address[] _owners, uint _required) {
     owners[1] = msg.sender;

--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -8,7 +8,7 @@ import '../ownership/Ownable.sol';
 
 /**
  * @title Mintable token
- * @dev: Simple ERC20 Token example, with mintable token creation
+ * @dev Simple ERC20 Token example, with mintable token creation
  * @dev Issue: * https://github.com/OpenZeppelin/zeppelin-solidity/issues/120
  * Based on code by TokenMarketNet: https://github.com/TokenMarketNet/ico/blob/master/contracts/MintableToken.sol
  */

--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -124,8 +124,8 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    * @param tokens uint256 The amount of tokens grantted.
    * @param time uint64 The time to be checked
    * @param start uint64 A time representing the begining of the grant
-   * @param _cliff uint64 The cliff period.
-   * @param _vesting uint64 The vesting period.
+   * @param cliff uint64 The cliff period.
+   * @param vesting uint64 The vesting period.
    * @return An uint representing the amount of vested tokensof a specif grant.
    */
   function calculateVestedTokens(


### PR DESCRIPTION
Fixes a few types in the new natspec documentation allowing ```truffle compile``` to run.
All tests are passing.
@maraoz @maurelian @JGcarv 