### PR TITLE
Create refundable token

### DIFF
--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -44,7 +44,7 @@ contract Bounty is PullPayment, Destructible {
 
   /**
    * @dev Sends the contract funds to the researcher that proved the contract is broken.
-   * @param Target contract
+   * @param target contract
    */
   function claim(Target target) {
     address researcher = researchers[target];

--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -101,7 +101,6 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
 
   /** 
    * @dev Resets the value spent to enable more spending
-   * @param _newLimit 
    */
   function resetSpentToday() onlymanyowners(keccak256(msg.data)) external {
     _resetSpentToday();

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -17,8 +17,8 @@ contract DelayedClaimable is Claimable {
   /**
    * @dev Used to specify the time period during which a pending 
    * owner can claim ownership. 
-   * @params _start The earliest time ownership can be claimed.
-   * @params _end The latest time ownership can be claimed. 
+   * @param _start The earliest time ownership can be claimed.
+   * @param _end The latest time ownership can be claimed. 
    */
   function setLimits(uint _start, uint _end) onlyOwner {
     if (_start > _end)

--- a/contracts/ownership/Shareable.sol
+++ b/contracts/ownership/Shareable.sol
@@ -58,7 +58,6 @@ contract Shareable {
    * transactions as well as the selection of addresses capable of confirming them.
    * @param _owners A list of owners.
    * @param _required The amount required for a transaction to be approved.
-   * @param _limit Uint to represent the daily limit.
    */
   function Shareable(address[] _owners, uint _required) {
     owners[1] = msg.sender;

--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -8,7 +8,7 @@ import '../ownership/Ownable.sol';
 
 /**
  * @title Mintable token
- * @dev: Simple ERC20 Token example, with mintable token creation
+ * @dev Simple ERC20 Token example, with mintable token creation
  * @dev Issue: * https://github.com/OpenZeppelin/zeppelin-solidity/issues/120
  * Based on code by TokenMarketNet: https://github.com/TokenMarketNet/ico/blob/master/contracts/MintableToken.sol
  */

--- a/contracts/token/RefundableToken.sol
+++ b/contracts/token/RefundableToken.sol
@@ -1,0 +1,70 @@
+pragma solidity ^0.4.8;
+
+
+import './StandardToken.sol';
+import '../ownership/Ownable.sol';
+import '../SafeMath.sol';
+
+
+/**
+ * @title Refundable token
+ * 
+ * @dev Simple ERC20 Token example, with refundable token creation.
+ * @dev Issue: https://github.com/OpenZeppelin/zeppelin-solidity/issues/217
+ *
+ * @notice Your main contract should inherit form this contract and implement the canRefund() method.
+ * @notice Warning -> If you do not implement canRefund() this will be an abstract contract.
+*/
+
+
+contract RefundableToken is StandardToken, Ownable {
+  event Refund(address indexed to, uint amount);
+
+  uint public refundRate = 100;
+
+  /**
+   * @dev Abstract function meant to be defined be token user.
+   * @return A boolean that indicates if the the token is currently refundable.
+   */
+
+  function canRefund() internal returns (bool);
+
+  /**
+   * @dev Function to set the refundRate of tokens to Ether.
+   * @param _newRefundRate Uint that updates the current refundRate.
+   */
+
+  function setRefundRate(uint _newRefundRate) onlyOwner {
+    refundRate = _newRefundRate;
+  }
+
+  /**
+   * @dev Function that allows users to refund tokens for Ether if canRefund returns True, they have enough tokens, and the contract has enough Ether.
+   * @param _amount Uint that is the amount of tokens the user wants to refund.
+   */
+
+  function refund(uint _amount) {
+    if (!canRefund() || _amount == 0) {
+      throw;
+    }
+
+    address _refundee = msg.sender;
+
+    if(balances[_refundee] < _amount) {
+      throw;
+    }
+
+    uint refund = _amount * (refundRate/100);
+
+    if (this.balance < refund) {
+      throw;
+    }
+
+    if (!_refundee.send(refund)) {
+      throw;
+    }
+
+    balances[_refundee] = balances[_refundee].sub(_amount);
+    Refund(_refundee, refund);
+  }
+}

--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -124,8 +124,8 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    * @param tokens uint256 The amount of tokens grantted.
    * @param time uint64 The time to be checked
    * @param start uint64 A time representing the begining of the grant
-   * @param _cliff uint64 The cliff period.
-   * @param _vesting uint64 The vesting period.
+   * @param cliff uint64 The cliff period.
+   * @param vesting uint64 The vesting period.
    * @return An uint representing the amount of vested tokensof a specif grant.
    */
   function calculateVestedTokens(

--- a/docs/source/refundabletoken.rst
+++ b/docs/source/refundabletoken.rst
@@ -1,0 +1,21 @@
+RefundableToken
+=============================================
+
+Simple ERC20 Token example, with refundable token creation.
+
+refundRate() returns (uint)
+"""""""""""""""""""""""""""""""""""""""""""""""
+Returns the current refundRate (token to Ether) in percent form.
+
+
+canRefund() internal returns (bool)
+"""""""""""""""""""""""""""""""""""""""""""""""
+An internal function that determines whether or not refunding is possible. Anyone who uses RefundableToken must define this function, otherwise the entire contract will be abstract.
+
+setRefundRate(uint _newRefundRate) onlyOwner
+"""""""""""""""""""""""""""""""""""""""""""""""
+Allows the owner to set the refundRate (the exchange rate from token to Ether in percent form).
+
+refund(uint _amount)
+"""""""""""""""""""""""""""""""""""""""""""""""
+Allows a token holder to get an Ether refund at the current refundRate if canRefund() returns True. Throws error if designated balance is 0, if the refundee does not have enough tokens, if contract does not hold enough funds to pay the refundee, or if the send transaction is not successful.

--- a/test/RefundableToken.js
+++ b/test/RefundableToken.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var RefundableTokenMock = artifacts.require('./helpers/RefundableTokenMock.sol');
+
+contract('RefundableToken', function(accounts) {
+  let AMOUNT;
+  let refundee;
+  let token;
+
+  beforeEach(async function() {
+    AMOUNT = 17*1e18;
+    refundee = accounts[1];
+    token = await RefundableTokenMock.new(refundee, AMOUNT, {value: AMOUNT});
+  });
+
+  it ('should return refundRate of 100 after contruction', async function () {
+    let refundRate = await token.refundRate();
+
+    assert.equal(refundRate, 100);
+  });
+
+  it ('should change refundRate to given amount', async function(){
+    await token.setRefundRate(50);
+    let refundRate = await token.refundRate();
+
+    assert.equal(refundRate, 50);
+  });
+
+  it ('should be able to give refund given the token amount', async function() {
+    let tokenAmount = AMOUNT/2; 
+
+    let balance1 = await token.balanceOf(refundee);
+    assert.equal(balance1, AMOUNT);
+
+    await token.refund(tokenAmount, {from: refundee});
+
+    let balance2 = await token.balanceOf(refundee);
+
+    assert.equal(balance2, tokenAmount);
+  });
+
+  it ('should be able to give refund based on the refundRate', async function() {
+    let refundee1 = accounts[1];
+    let refundee2 = accounts[2];
+    let refundee3 = accounts[3];
+
+    let token1 = await RefundableTokenMock.new(refundee1, AMOUNT, {value: AMOUNT, from: accounts[7]});
+    let token2 = await RefundableTokenMock.new(refundee2, AMOUNT, {value: AMOUNT, from: accounts[8]});
+    let token3 = await RefundableTokenMock.new(refundee3, AMOUNT, {value: AMOUNT, from: accounts[9]});
+
+    await token1.setRefundRate(50, {from: accounts[7]});
+    await token3.setRefundRate(150, {from: accounts[9]});
+
+    await token1.refund(AMOUNT, {from: refundee1});
+    await token2.refund(AMOUNT, {from: refundee2});
+    await token3.refund(AMOUNT, {from: refundee3});
+
+    let endBalance1 = web3.eth.getBalance(refundee1);
+    let endBalance2 = web3.eth.getBalance(refundee2);
+    let endBalance3 = web3.eth.getBalance(refundee2);
+
+    assert(endBalance1 < endBalance2 < endBalance3);
+  });
+})

--- a/test/helpers/RefundableTokenMock.sol
+++ b/test/helpers/RefundableTokenMock.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.8;
+
+
+import '../../contracts/token/RefundableToken.sol';
+
+
+// mock class using RefundableToken
+contract RefundableTokenMock is RefundableToken {
+
+  function RefundableTokenMock(address initialAccount, uint initialBalance) payable {
+    balances[initialAccount] = initialBalance;
+    totalSupply = initialBalance;
+  }
+
+  function canRefund() internal returns (bool) {
+    return true;
+  }
+
+}


### PR DESCRIPTION
This contract was created in response to issue #217 
The basic idea is to create a refundable token that can return Ether for tokens if a user chooses to do so.
Creates, tests and documents a refundable token.
The owner is able to set the refund rate (token to ether).
```canRefund()``` needs to to be defined in a child contract and return ```True``` for ```RefundableToken```  to work.
Also fixes more documentation typos.
@maraoz 