### PR TITLE
Removed onlyOwner modifyer from mint function

### DIFF
--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -32,7 +32,7 @@ contract MintableToken is StandardToken, Ownable {
    * @param _amount The amount of tokens to mint.
    * @return A boolean that indicates if the operation was successful.
    */
-  function mint(address _to, uint _amount) onlyOwner canMint returns (bool) {
+  function mint(address _to, uint _amount) canMint returns (bool) {
     totalSupply = totalSupply.add(_amount);
     balances[_to] = balances[_to].add(_amount);
     Mint(_to, _amount);


### PR DESCRIPTION
The idea is that a regular investor of an ICO for example could invest and the mintage of the token would happen instantaneously in that situation. The onlyOwner modifyer can be then applied in a child contract to avoid mintage to happen by non owners for example.