### PR TITLE
Upgrade to Truffle version 3.2.2 and Solidity version 0.4.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: node_js
 node_js:
   - "6"
 before_install:
-  - npm install truffle@3.1.9 -g
+  - npm install truffle@3.2.2 -g
   - npm i -g ethereumjs-testrpc
 script:
   - testrpc > /dev/null &

--- a/audit/ZeppelinAudit.md
+++ b/audit/ZeppelinAudit.md
@@ -48,7 +48,7 @@ We think much more could be done here, and recommend the OpenZeppelin team keep 
 
 ## Solidity Version Updates Recommended
 
-Most of the code uses Solidity 0.4.8, but some files under `Ownership` are marked 0.4.0. These should be updated.
+Most of the code uses Solidity 0.4.11, but some files under `Ownership` are marked 0.4.0. These should be updated.
 
 Solidity 0.4.10 will add several features which could be useful in these contracts:
 

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './payment/PullPayment.sol';

--- a/contracts/DayLimit.sol
+++ b/contracts/DayLimit.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 /**
  * @title DayLimit

--- a/contracts/LimitBalance.sol
+++ b/contracts/LimitBalance.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "./ownership/Multisig.sol";
@@ -93,7 +93,7 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
 
   /** 
    * @dev Updates the daily limit value. 
-   * @param _newLimit 
+   * @param _newLimit  Uint to represent the new limit.
    */
   function setDailyLimit(uint _newLimit) onlymanyowners(keccak256(msg.data)) external {
     _setDailyLimit(_newLimit);

--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 /**
  * @title Helps contracts guard agains rentrancy attacks.

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/lifecycle/Destructible.sol
+++ b/contracts/lifecycle/Destructible.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "../ownership/Ownable.sol";
@@ -9,6 +9,8 @@ import "../ownership/Ownable.sol";
  * @dev Base contract that can be destroyed by owner. All funds in contract will be sent to the owner.
  */
 contract Destructible is Ownable {
+
+  function Destructible() payable { } 
 
   /**
    * @dev Transfers the current balance to the owner and terminates the contract. 

--- a/contracts/lifecycle/Migrations.sol
+++ b/contracts/lifecycle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../ownership/Ownable.sol';

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "../ownership/Ownable.sol";

--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "../ownership/Ownable.sol";
@@ -11,6 +11,8 @@ import "../token/ERC20Basic.sol";
  * listed tokens will be sent to the owner.
  */
 contract TokenDestructible is Ownable {
+
+  function TokenDestructible() payable { } 
 
   /** 
    * @notice Terminate contract and refund to owner

--- a/contracts/ownership/Claimable.sol
+++ b/contracts/ownership/Claimable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './Ownable.sol';

--- a/contracts/ownership/Contactable.sol
+++ b/contracts/ownership/Contactable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import './Ownable.sol';
 

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './Claimable.sol';

--- a/contracts/ownership/HasNoContracts.sol
+++ b/contracts/ownership/HasNoContracts.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./Ownable.sol";
 

--- a/contracts/ownership/HasNoEther.sol
+++ b/contracts/ownership/HasNoEther.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./Ownable.sol";
 

--- a/contracts/ownership/HasNoTokens.sol
+++ b/contracts/ownership/HasNoTokens.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./Ownable.sol";
 import "../token/ERC20Basic.sol";

--- a/contracts/ownership/Multisig.sol
+++ b/contracts/ownership/Multisig.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/ownership/NoOwner.sol
+++ b/contracts/ownership/NoOwner.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./HasNoEther.sol";
 import "./HasNoTokens.sol";

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/ownership/Shareable.sol
+++ b/contracts/ownership/Shareable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../SafeMath.sol';

--- a/contracts/token/BasicToken.sol
+++ b/contracts/token/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './ERC20Basic.sol';

--- a/contracts/token/CrowdsaleToken.sol
+++ b/contracts/token/CrowdsaleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "./StandardToken.sol";

--- a/contracts/token/ERC20.sol
+++ b/contracts/token/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './ERC20Basic.sol';

--- a/contracts/token/ERC20Basic.sol
+++ b/contracts/token/ERC20Basic.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 /**

--- a/contracts/token/LimitedTransferToken.sol
+++ b/contracts/token/LimitedTransferToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./ERC20.sol";
 

--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './StandardToken.sol';

--- a/contracts/token/PausableToken.sol
+++ b/contracts/token/PausableToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import './StandardToken.sol';
 import '../lifecycle/Pausable.sol';

--- a/contracts/token/SimpleToken.sol
+++ b/contracts/token/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import "./StandardToken.sol";

--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import './BasicToken.sol';

--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "./StandardToken.sol";
 import "./LimitedTransferToken.sol";

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "ethereumjs-testrpc": "^3.0.2",
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "^0.1.0",
-    "truffle": "https://github.com/ConsenSys/truffle.git#3.1.9"
+    "truffle": "3.2.2"
   }
 }

--- a/test/DelayedClaimble.js
+++ b/test/DelayedClaimble.js
@@ -49,7 +49,7 @@ contract('DelayedClaimable', function(accounts) {
     } catch (error) {
       err = error;
     }
-    assert.isFalse(err.message.search('invalid JUMP') === -1);
+    assert.isFalse(err.message.search('invalid opcode') === -1);
     let owner = await delayedClaimable.owner();
     assert.isTrue(owner !== accounts[1]);
   });
@@ -62,7 +62,7 @@ contract('DelayedClaimable', function(accounts) {
     } catch (error) {
       err = error;
     }
-    assert.isFalse(err.message.search('invalid JUMP') === -1);
+    assert.isFalse(err.message.search('invalid opcode') === -1);
   });
 
 });

--- a/test/HasNoEther.js
+++ b/test/HasNoEther.js
@@ -35,7 +35,8 @@ contract('HasNoEther', function(accounts) {
     assert.equal(startBalance, 0);
 
     // Force ether into it
-    await ForceEther.new(hasNoEther.address, {value: amount});
+    let forceEther = await ForceEther.new({value: amount});
+    await forceEther.destroyAndSend(hasNoEther.address);
     const forcedBalance = await web3.eth.getBalance(hasNoEther.address);
     assert.equal(forcedBalance, amount);
 
@@ -53,7 +54,8 @@ contract('HasNoEther', function(accounts) {
     let hasNoEther = await HasNoEtherTest.new({from: accounts[0]});
 
     // Force ether into it
-    await ForceEther.new(hasNoEther.address, {value: amount});
+    let forceEther = await ForceEther.new({value: amount});
+    await forceEther.destroyAndSend(hasNoEther.address);
     const forcedBalance = await web3.eth.getBalance(hasNoEther.address);
     assert.equal(forcedBalance, amount);
 

--- a/test/helpers/BasicTokenMock.sol
+++ b/test/helpers/BasicTokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/token/BasicToken.sol';

--- a/test/helpers/DayLimitMock.sol
+++ b/test/helpers/DayLimitMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 import "../../contracts/DayLimit.sol";
 
 contract DayLimitMock is DayLimit {

--- a/test/helpers/ERC23TokenMock.sol
+++ b/test/helpers/ERC23TokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/token/BasicToken.sol';

--- a/test/helpers/ForceEther.sol
+++ b/test/helpers/ForceEther.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 // @title Force Ether into a contract.
 // @notice  even
@@ -6,8 +6,10 @@ pragma solidity ^0.4.8;
 // @notice To use, construct the contract with the target as argument.
 // @author Remco Bloemen <remco@neufund.org>
 contract ForceEther  {
-  function ForceEther(address target) payable {
-    // Selfdestruct transfers all Ether to the arget address
-    selfdestruct(target);
+
+  function ForceEther() payable { }
+
+  function destroyAndSend(address _recipient) {
+    selfdestruct(_recipient);
   }
 }

--- a/test/helpers/HasNoEtherTest.sol
+++ b/test/helpers/HasNoEtherTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import "../../contracts/ownership/HasNoEther.sol";
 

--- a/test/helpers/InsecureTargetBounty.sol
+++ b/test/helpers/InsecureTargetBounty.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import {Bounty, Target} from "../../contracts/Bounty.sol";

--- a/test/helpers/LimitBalanceMock.sol
+++ b/test/helpers/LimitBalanceMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/LimitBalance.sol';

--- a/test/helpers/MultisigWalletMock.sol
+++ b/test/helpers/MultisigWalletMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 import "../../contracts/MultisigWallet.sol";
 
 contract MultisigWalletMock is MultisigWallet {

--- a/test/helpers/PausableMock.sol
+++ b/test/helpers/PausableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/lifecycle/Pausable.sol';

--- a/test/helpers/PausableTokenMock.sol
+++ b/test/helpers/PausableTokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import '../../contracts/token/PausableToken.sol';
 

--- a/test/helpers/PullPaymentMock.sol
+++ b/test/helpers/PullPaymentMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/payment/PullPayment.sol';

--- a/test/helpers/ReentrancyAttack.sol
+++ b/test/helpers/ReentrancyAttack.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 contract ReentrancyAttack {
 

--- a/test/helpers/ReentrancyMock.sol
+++ b/test/helpers/ReentrancyMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import '../../contracts/ReentrancyGuard.sol';
 import './ReentrancyAttack.sol';

--- a/test/helpers/SafeMathMock.sol
+++ b/test/helpers/SafeMathMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/SafeMath.sol';

--- a/test/helpers/SecureTargetBounty.sol
+++ b/test/helpers/SecureTargetBounty.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import {Bounty, Target} from "../../contracts/Bounty.sol";

--- a/test/helpers/ShareableMock.sol
+++ b/test/helpers/ShareableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 import "../../contracts/ownership/Shareable.sol";
 
 contract ShareableMock is Shareable {

--- a/test/helpers/StandardTokenMock.sol
+++ b/test/helpers/StandardTokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 
 import '../../contracts/token/StandardToken.sol';

--- a/test/helpers/VestedTokenMock.sol
+++ b/test/helpers/VestedTokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.11;
 
 import '../../contracts/token/VestedToken.sol';
 

--- a/test/helpers/assertJump.js
+++ b/test/helpers/assertJump.js
@@ -1,3 +1,3 @@
 module.exports = function(error) {
-  assert.isAbove(error.message.search('invalid JUMP'), -1, 'Invalid JUMP error must be returned');
+  assert.isAbove(error.message.search('invalid opcode'), -1, 'Invalid opcode error must be returned');
 }

--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -4,14 +4,14 @@ export default async promise => {
   } catch (error) {
     // TODO: Check jump destination to destinguish between a throw
     //       and an actual invalid jump.
-    const invalidJump = error.message.search('invalid JUMP') >= 0;
+    const invalidOpcode = error.message.search('invalid opcode') >= 0;
     // TODO: When we contract A calls contract B, and B throws, instead
     //       of an 'invalid jump', we get an 'out of gas' error. How do
     //       we distinguish this from an actual out of gas event? (The
     //       testrpc log actually show an 'invalid jump' event.)
     const outOfGas = error.message.search('out of gas') >= 0;
     assert(
-      invalidJump || outOfGas,
+      invalidOpcode || outOfGas,
       "Expected throw, got '" + error + "' instead",
     );
     return;


### PR DESCRIPTION
This contract was created in response to issue #215 
It upgrades Solidity to  ```0.4.11``` from  ```0.4.8```
It upgrades Truffle to ```3.2.2``` from ```3.1.9```
```ForceEther``` contract had to be changed because contracts can no longer ```selfdestruct``` in the constructor.
All tests are passing.
@maraoz