### PR TITLE
Description of param _newLimit in setDailyLimit missing.

### DIFF
--- a/contracts/MultisigWallet.sol
+++ b/contracts/MultisigWallet.sol
@@ -93,7 +93,7 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
 
   /** 
    * @dev Updates the daily limit value. 
-   * @param _newLimit 
+   * @param _newLimit Uint to represent the new limit.
    */
   function setDailyLimit(uint _newLimit) onlymanyowners(keccak256(msg.data)) external {
     _setDailyLimit(_newLimit);


### PR DESCRIPTION
Description of param _newLimit in setDailyLimit(uint _newLimit) at MultisigWallet.sol was missing producing a "No description given for param _newLimit" compilation error.

Tested in Truffle v3.2.5 and node v6.10.3