### PR TITLE
Refactor MintableToken Contract

### DIFF
--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -14,11 +14,10 @@ import '../ownership/Ownable.sol';
  */
 
 contract MintableToken is StandardToken, Ownable {
-  event Mint(address indexed to, uint value);
+  event Mint(address indexed to, uint amount);
   event MintFinished();
 
   bool public mintingFinished = false;
-  uint public totalSupply = 0;
 
 
   modifier canMint() {


### PR DESCRIPTION
These refactors were done in response to issues #255 and #245 
It removes a redundant state variable ```totalSupply``` and changes ```value``` to ```amount```
All tests are passing!
@maraoz