### PR TITLE
Update SafeMath to be a contract instead of a library

### DIFF
--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -4,44 +4,44 @@ pragma solidity ^0.4.11;
 /**
  * Math operations with safety checks
  */
-library SafeMath {
-  function mul(uint a, uint b) internal returns (uint) {
+contract SafeMath {
+  function mul(uint a, uint b) public returns (uint) {
     uint c = a * b;
     assert(a == 0 || c / a == b);
     return c;
   }
 
-  function div(uint a, uint b) internal returns (uint) {
+  function div(uint a, uint b) public returns (uint) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
     uint c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
-  function sub(uint a, uint b) internal returns (uint) {
+  function sub(uint a, uint b) public returns (uint) {
     assert(b <= a);
     return a - b;
   }
 
-  function add(uint a, uint b) internal returns (uint) {
+  function add(uint a, uint b) public returns (uint) {
     uint c = a + b;
     assert(c >= a);
     return c;
   }
 
-  function max64(uint64 a, uint64 b) internal constant returns (uint64) {
+  function max64(uint64 a, uint64 b) public constant returns (uint64) {
     return a >= b ? a : b;
   }
 
-  function min64(uint64 a, uint64 b) internal constant returns (uint64) {
+  function min64(uint64 a, uint64 b) public constant returns (uint64) {
     return a < b ? a : b;
   }
 
-  function max256(uint256 a, uint256 b) internal constant returns (uint256) {
+  function max256(uint256 a, uint256 b) public constant returns (uint256) {
     return a >= b ? a : b;
   }
 
-  function min256(uint256 a, uint256 b) internal constant returns (uint256) {
+  function min256(uint256 a, uint256 b) public constant returns (uint256) {
     return a < b ? a : b;
   }
 


### PR DESCRIPTION
So right now contract dependencies are a nightmare, but I would hope that down the line someone could just call the one SafeMath contract on whatever net they were on instead of having to inherit its functionality.