### PR TITLE
Add explicit throw to BasicToken.transfer

### DIFF
--- a/contracts/token/BasicToken.sol
+++ b/contracts/token/BasicToken.sol
@@ -30,7 +30,9 @@ contract BasicToken is ERC20Basic {
   * @param _value The amount to be transferred.
   */
   function transfer(address _to, uint256 _value) onlyPayloadSize(2 * 32) {
-    balances[msg.sender] = balances[msg.sender].sub(_value);
+    if(balances[msg.sender] < _value) throw;
+
+    balances[msg.sender] -= _value;
     balances[_to] = balances[_to].add(_value);
     Transfer(msg.sender, _to, _value);
   }


### PR DESCRIPTION
The `transfer` method follows a suggestion currently in the draft of the ERC20 spec, that says the method should `throw` in the event of insufficient balance. However, this `throw` is currently implicitly done in the call to `SafeMath.sub`. This is confusing to anyone reading the code, as it initially implies that no guard is done against an invalid transfer. Moreover, it doesn't clearly illustrate the `throw` condition - this would require someone to dig into `SafeMath.sub` in order to find answers.

Additionally, this implicitly depends on `SafeMath.sub` not to change its semantics. I make no claim as to how likely this is, but if `SafeMath.sub` were to be changed to not `throw`, then suddenly `BasicMath.transfer` would be broken.

Changes made:
* `BasicToken.transfer` now explicitly throws if there is insufficient balance to carry out the transfer.
* The deducted amount no longer uses `SafeMath.sub`, since the `throw` condition makes underflow impossible.

Effectively, the code is still semantically the same as before - however it illustrates the API in a more explicit manner. It also guards against any changes to the implementation of `SafeMath.sub`.

Any feedback or opinion would be most appreciated.