### PR TITLE
Move SafeMath and create Math library for assorted operations

### DIFF
--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.4.11;
+
+/**
+ * @title Math
+ * @dev Assorted math operations
+ */
+
+contract Math {
+  function max64(uint64 a, uint64 b) internal constant returns (uint64) {
+    return a >= b ? a : b;
+  }
+
+  function min64(uint64 a, uint64 b) internal constant returns (uint64) {
+    return a < b ? a : b;
+  }
+
+  function max256(uint256 a, uint256 b) internal constant returns (uint256) {
+    return a >= b ? a : b;
+  }
+
+  function min256(uint256 a, uint256 b) internal constant returns (uint256) {
+    return a < b ? a : b;
+  }
+}

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.4.11;
  * @dev Assorted math operations
  */
 
-contract Math {
+library Math {
   function max64(uint64 a, uint64 b) internal constant returns (uint64) {
     return a >= b ? a : b;
   }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -2,7 +2,8 @@ pragma solidity ^0.4.11;
 
 
 /**
- * Math operations with safety checks
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
   function mul(uint256 a, uint256 b) internal returns (uint256) {

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -29,21 +29,4 @@ library SafeMath {
     assert(c >= a);
     return c;
   }
-
-  function max64(uint64 a, uint64 b) internal constant returns (uint64) {
-    return a >= b ? a : b;
-  }
-
-  function min64(uint64 a, uint64 b) internal constant returns (uint64) {
-    return a < b ? a : b;
-  }
-
-  function max256(uint256 a, uint256 b) internal constant returns (uint256) {
-    return a >= b ? a : b;
-  }
-
-  function min256(uint256 a, uint256 b) internal constant returns (uint256) {
-    return a < b ? a : b;
-  }
-
 }

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.11;
 
 
-import '../SafeMath.sol';
+import '../math/SafeMath.sol';
 
 
 /**

--- a/contracts/token/BasicToken.sol
+++ b/contracts/token/BasicToken.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.11;
 
 
 import './ERC20Basic.sol';
-import '../SafeMath.sol';
+import '../math/SafeMath.sol';
 
 
 /**

--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.11;
 
+import "../math/Math.sol";
 import "./StandardToken.sol";
 import "./LimitedTransferToken.sol";
 
@@ -121,7 +122,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
 
     // Return the minimum of how many vested can transfer and other value
     // in case there are other limiting transferability factors (default is balanceOf)
-    return SafeMath.min256(vestedTransferable, super.transferableTokens(holder, time));
+    return Math.min256(vestedTransferable, super.transferableTokens(holder, time));
   }
 
   /**
@@ -241,7 +242,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
     date = uint64(now);
     uint256 grantIndex = grants[holder].length;
     for (uint256 i = 0; i < grantIndex; i++) {
-      date = SafeMath.max64(grants[holder][i].vesting, date);
+      date = Math.max64(grants[holder][i].vesting, date);
     }
   }
 }

--- a/test/helpers/SafeMathMock.sol
+++ b/test/helpers/SafeMathMock.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.11;
 
 
-import '../../contracts/SafeMath.sol';
+import '../../contracts/math/SafeMath.sol';
 
 
 contract SafeMathMock {


### PR DESCRIPTION
In a future release, I'd like us to provide an alternative lower-level SafeMath library that doesn't throw on error, instead returning a boolean value. This will enable handling math errors in ways other than throwing. If ERC20 ends up keeping the boolean return values, such a library will be needed to implement it.

To prepare for it I've moved the SafeMath library into a _math_ directory, where both will live. Additionally I've moved `max`/`min` operations into a separate `Math` library since they're not about safety.