### PR TITLE
Test if unpause prevents events allowed in paused state

### DIFF
--- a/test/Pausable.js
+++ b/test/Pausable.js
@@ -62,4 +62,18 @@ contract('Pausable', function(accounts) {
     assert.equal(count0, 1);
   });
 
+  it('should prevent drastic measure after pause is over', async function() {
+    let Pausable = await PausableMock.new();
+    await Pausable.pause();
+    await Pausable.unpause();
+    try {
+      await Pausable.drasticMeasure();
+    } catch(error) {
+      assertJump(error);
+    }
+
+    const drasticMeasureTaken = await Pausable.drasticMeasureTaken();
+    assert.isFalse(drasticMeasureTaken);
+  });
+
 });


### PR DESCRIPTION
Just a minor update to fully cover all of the possible execution branches. There was no testing scenario to check whether unpause resume blocking execution of methods marked as whenPaused.