### PR TITLE
Make ERC20 and token contracts conform to standard

### DIFF
--- a/contracts/token/BasicToken.sol
+++ b/contracts/token/BasicToken.sol
@@ -19,10 +19,11 @@ contract BasicToken is ERC20Basic {
   * @param _to The address to transfer to.
   * @param _value The amount to be transferred.
   */
-  function transfer(address _to, uint256 _value) {
+  function transfer(address _to, uint256 _value) returns (bool) {
     balances[msg.sender] = balances[msg.sender].sub(_value);
     balances[_to] = balances[_to].add(_value);
     Transfer(msg.sender, _to, _value);
+    return true;
   }
 
   /**

--- a/contracts/token/ERC20.sol
+++ b/contracts/token/ERC20.sol
@@ -10,7 +10,7 @@ import './ERC20Basic.sol';
  */
 contract ERC20 is ERC20Basic {
   function allowance(address owner, address spender) constant returns (uint256);
-  function transferFrom(address from, address to, uint256 value);
-  function approve(address spender, uint256 value);
+  function transferFrom(address from, address to, uint256 value) returns (bool);
+  function approve(address spender, uint256 value) returns (bool);
   event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/token/ERC20Basic.sol
+++ b/contracts/token/ERC20Basic.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.4.11;
 /**
  * @title ERC20Basic
  * @dev Simpler version of ERC20 interface
- * @dev see https://github.com/ethereum/EIPs/issues/20
+ * @dev see https://github.com/ethereum/EIPs/issues/179
  */
 contract ERC20Basic {
   uint256 public totalSupply;
   function balanceOf(address who) constant returns (uint256);
-  function transfer(address to, uint256 value);
+  function transfer(address to, uint256 value) returns (bool);
   event Transfer(address indexed from, address indexed to, uint256 value);
 }

--- a/contracts/token/LimitedTransferToken.sol
+++ b/contracts/token/LimitedTransferToken.sol
@@ -32,8 +32,8 @@ contract LimitedTransferToken is ERC20 {
    * @param _to The address that will recieve the tokens.
    * @param _value The amount of tokens to be transferred.
    */
-  function transfer(address _to, uint256 _value) canTransfer(msg.sender, _value) {
-    super.transfer(_to, _value);
+  function transfer(address _to, uint256 _value) canTransfer(msg.sender, _value) returns (bool) {
+    return super.transfer(_to, _value);
   }
 
   /**
@@ -42,8 +42,8 @@ contract LimitedTransferToken is ERC20 {
   * @param _to The address that will recieve the tokens.
   * @param _value The amount of tokens to be transferred.
   */
-  function transferFrom(address _from, address _to, uint256 _value) canTransfer(_from, _value) {
-    super.transferFrom(_from, _to, _value);
+  function transferFrom(address _from, address _to, uint256 _value) canTransfer(_from, _value) returns (bool) {
+    return super.transferFrom(_from, _to, _value);
   }
 
   /**

--- a/contracts/token/PausableToken.sol
+++ b/contracts/token/PausableToken.sol
@@ -11,11 +11,11 @@ import '../lifecycle/Pausable.sol';
 
 contract PausableToken is StandardToken, Pausable {
 
-  function transfer(address _to, uint _value) whenNotPaused {
-    super.transfer(_to, _value);
+  function transfer(address _to, uint _value) whenNotPaused returns (bool) {
+    return super.transfer(_to, _value);
   }
 
-  function transferFrom(address _from, address _to, uint _value) whenNotPaused {
-    super.transferFrom(_from, _to, _value);
+  function transferFrom(address _from, address _to, uint _value) whenNotPaused returns (bool) {
+    return super.transferFrom(_from, _to, _value);
   }
 }

--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -23,7 +23,7 @@ contract StandardToken is ERC20, BasicToken {
    * @param _to address The address which you want to transfer to
    * @param _value uint256 the amout of tokens to be transfered
    */
-  function transferFrom(address _from, address _to, uint256 _value) {
+  function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
     var _allowance = allowed[_from][msg.sender];
 
     // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
@@ -33,6 +33,7 @@ contract StandardToken is ERC20, BasicToken {
     balances[_from] = balances[_from].sub(_value);
     allowed[_from][msg.sender] = _allowance.sub(_value);
     Transfer(_from, _to, _value);
+    return true;
   }
 
   /**
@@ -40,7 +41,7 @@ contract StandardToken is ERC20, BasicToken {
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */
-  function approve(address _spender, uint256 _value) {
+  function approve(address _spender, uint256 _value) returns (bool) {
 
     // To change the approve amount you first have to reduce the addresses`
     //  allowance to zero by calling `approve(_spender, 0)` if it is not
@@ -50,6 +51,7 @@ contract StandardToken is ERC20, BasicToken {
 
     allowed[msg.sender][_spender] = _value;
     Approval(msg.sender, _spender, _value);
+    return true;
   }
 
   /**


### PR DESCRIPTION
This adds back the boolean return values to the ERC20 interface and all the token implementations. Fixes the following two problems that were caused by not having them.
1. If anyone interacted with an OpenZeppelin token assuming it was ERC20, they would see false return values even for successful operations.
2. If a user of OpenZeppelin interacted with an ERC20 compliant contract through our Solidity interface, they wouldn't be able to see false return values, instead ignoring errors. (Fixes #270)

Although we're still throwing on errors instead of returning false, close #163 as well, since we're doing as the standard recommends, e.g.:
>  The function SHOULD throw if the _from account balance has not enough tokens to spend.