### PR TITLE
[WIP] Allow custom rate function in crowdsales

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -24,9 +24,6 @@ contract Crowdsale {
   // address where funds are collected
   address public wallet;
 
-  // how many token units a buyer gets per wei
-  uint256 public rate;
-
   // amount of raised money in wei
   uint256 public weiRaised;
 
@@ -40,25 +37,24 @@ contract Crowdsale {
   event TokenPurchase(address indexed purchaser, address indexed beneficiary, uint256 value, uint256 amount);
 
 
-  function Crowdsale(uint256 _startBlock, uint256 _endBlock, uint256 _rate, address _wallet) {
+  function Crowdsale(uint256 _startBlock, uint256 _endBlock, address _wallet) {
     require(_startBlock >= block.number);
     require(_endBlock >= _startBlock);
-    require(_rate > 0);
     require(_wallet != 0x0);
 
     token = createTokenContract();
     startBlock = _startBlock;
     endBlock = _endBlock;
-    rate = _rate;
     wallet = _wallet;
   }
+
+  function getRate() returns (uint256);
 
   // creates the token to be sold. 
   // override this method to have crowdsale of a specific mintable token.
   function createTokenContract() internal returns (MintableToken) {
     return new MintableToken();
   }
-
 
   // fallback function can be used to buy tokens
   function () payable {
@@ -73,7 +69,7 @@ contract Crowdsale {
     uint256 weiAmount = msg.value;
 
     // calculate token amount to be created
-    uint256 tokens = weiAmount.mul(rate);
+    uint256 tokens = weiAmount.mul(getRate());
 
     // update state
     weiRaised = weiRaised.add(weiAmount);

--- a/contracts/crowdsale/FixedRate.sol
+++ b/contracts/crowdsale/FixedRate.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.11;
+
+import './Crowdsale.sol';
+
+contract FixedRate is Crowdsale {
+  uint256 rate;
+
+  function FixedRate(uint256 _rate) {
+    rate = _rate;
+  }
+
+  function getRate() returns (uint256) {
+    return rate;
+  }
+}

--- a/test/Crowdsale.js
+++ b/test/Crowdsale.js
@@ -9,7 +9,7 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
-const Crowdsale = artifacts.require('Crowdsale')
+const Crowdsale = artifacts.require('./helpers/CrowdsaleImpl.sol')
 const MintableToken = artifacts.require('MintableToken')
 
 contract('Crowdsale', function ([_, investor, wallet, purchaser]) {

--- a/test/helpers/CrowdsaleImpl.sol
+++ b/test/helpers/CrowdsaleImpl.sol
@@ -1,21 +1,17 @@
 pragma solidity ^0.4.11;
 
-
-import '../../contracts/crowdsale/CappedCrowdsale.sol';
+import '../../contracts/crowdsale/Crowdsale.sol';
 import '../../contracts/crowdsale/FixedRate.sol';
 
+contract CrowdsaleImpl is Crowdsale, FixedRate {
 
-contract CappedCrowdsaleImpl is CappedCrowdsale, FixedRate {
-
-  function CappedCrowdsaleImpl (
+  function CrowdsaleImpl (
     uint256 _startBlock,
     uint256 _endBlock,
     uint256 _rate,
-    address _wallet,
-    uint256 _cap
+    address _wallet
   )
     Crowdsale(_startBlock, _endBlock, _wallet)
-    CappedCrowdsale(_cap) 
     FixedRate(_rate)
   {
   }

--- a/test/helpers/FinalizableCrowdsaleImpl.sol
+++ b/test/helpers/FinalizableCrowdsaleImpl.sol
@@ -2,9 +2,10 @@ pragma solidity ^0.4.11;
 
 
 import '../../contracts/crowdsale/FinalizableCrowdsale.sol';
+import '../../contracts/crowdsale/FixedRate.sol';
 
 
-contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
+contract FinalizableCrowdsaleImpl is FinalizableCrowdsale, FixedRate {
 
   function FinalizableCrowdsaleImpl (
     uint256 _startBlock,
@@ -12,8 +13,9 @@ contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
     uint256 _rate,
     address _wallet
   )
-    Crowdsale(_startBlock, _endBlock, _rate, _wallet)
+    Crowdsale(_startBlock, _endBlock, _wallet)
     FinalizableCrowdsale() 
+    FixedRate(_rate)
   {
   }
 

--- a/test/helpers/RefundableCrowdsaleImpl.sol
+++ b/test/helpers/RefundableCrowdsaleImpl.sol
@@ -2,9 +2,10 @@ pragma solidity ^0.4.11;
 
 
 import '../../contracts/crowdsale/RefundableCrowdsale.sol';
+import '../../contracts/crowdsale/FixedRate.sol';
 
 
-contract RefundableCrowdsaleImpl is RefundableCrowdsale {
+contract RefundableCrowdsaleImpl is RefundableCrowdsale, FixedRate {
 
   function RefundableCrowdsaleImpl (
     uint256 _startBlock,
@@ -13,8 +14,9 @@ contract RefundableCrowdsaleImpl is RefundableCrowdsale {
     address _wallet,
     uint256 _goal
   )
-    Crowdsale(_startBlock, _endBlock, _rate, _wallet)
+    Crowdsale(_startBlock, _endBlock, _wallet)
     RefundableCrowdsale(_goal) 
+    FixedRate(_rate)
   {
   }
 


### PR DESCRIPTION
Fixes #302.

An abstract function `getRate()` is added to `Crowdsale`, which allows setting a custom rate function. The function was intentionally left public to allow querying the rate before buying.

The implementation of the current behavior is moved to `FixedRate`.

Throwing the idea in here to see what people think.