### PR TITLE
Fix/ownable error - Silent transferOwnership Failure

### DIFF
--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -33,9 +33,8 @@ contract Ownable {
    * @param newOwner The address to transfer ownership to.
    */
   function transferOwnership(address newOwner) onlyOwner {
-    if (newOwner != address(0)) {
-      owner = newOwner;
-    }
+    require(newOwner != address(0));      
+    owner = newOwner;
   }
 
 }

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -38,7 +38,7 @@ contract('Ownable', function(accounts) {
     let originalOwner = await ownable.owner();
     try {
       await ownable.transferOwnership(null, {from: originalOwner});
-      assert.fail()
+      assert.fail();
     } catch(error) {
       assertJump(error);
     }

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -1,45 +1,45 @@
-'use strict';
-const assertJump = require('./helpers/assertJump');
+'use strict'
+const assertJump = require('./helpers/assertJump')
 
-var Ownable = artifacts.require('../contracts/ownership/Ownable.sol');
+var Ownable = artifacts.require('../contracts/ownership/Ownable.sol')
 
-contract('Ownable', function(accounts) {
-  let ownable;
+contract('Ownable', function (accounts) {
+  let ownable
 
-  beforeEach(async function() {
-    ownable = await Ownable.new();
-  });
+  beforeEach(async function () {
+    ownable = await Ownable.new()
+  })
 
-  it('should have an owner', async function() {
-    let owner = await ownable.owner();
-    assert.isTrue(owner !== 0);
-  });
+  it('should have an owner', async function () {
+    let owner = await ownable.owner()
+    assert.isTrue(owner !== 0)
+  })
 
-  it('changes owner after transfer', async function() {
-    let other = accounts[1];
-    await ownable.transferOwnership(other);
-    let owner = await ownable.owner();
+  it('changes owner after transfer', async function () {
+    let other = accounts[1]
+    await ownable.transferOwnership(other)
+    let owner = await ownable.owner()
 
-    assert.isTrue(owner === other);
-  });
+    assert.isTrue(owner === other)
+  })
 
-  it('should prevent non-owners from transfering', async function() {
-    const other = accounts[2];
-    const owner = await ownable.owner.call();
-    assert.isTrue(owner !== other);
+  it('should prevent non-owners from transfering', async function () {
+    const other = accounts[2]
+    const owner = await ownable.owner.call()
+    assert.isTrue(owner !== other)
     try {
-      await ownable.transferOwnership(other, {from: other});
-    } catch(error) {
-      assertJump(error);
+      await ownable.transferOwnership(other, {from: other})
+    } catch (error) {
+      assertJump(error)
     }
-  });
+  })
 
-  it('should guard ownership against stuck state', async function() {
-    let originalOwner = await ownable.owner();
-    await ownable.transferOwnership(null, {from: originalOwner});
-    let newOwner = await ownable.owner();
-
-    assert.equal(originalOwner, newOwner);
-  });
-
-});
+  it('should guard ownership against stuck state setting owner as 0x0 address', async function () {
+    let originalOwner = await ownable.owner()
+    try {
+      await ownable.transferOwnership(null, {from: originalOwner})
+    } catch (error) {
+      assertJump(error)
+    }
+  })
+})

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -1,45 +1,46 @@
-'use strict'
-const assertJump = require('./helpers/assertJump')
+'use strict';
+const assertJump = require('./helpers/assertJump');
 
-var Ownable = artifacts.require('../contracts/ownership/Ownable.sol')
+var Ownable = artifacts.require('../contracts/ownership/Ownable.sol');
 
-contract('Ownable', function (accounts) {
-  let ownable
+contract('Ownable', function(accounts) {
+  let ownable;
 
-  beforeEach(async function () {
-    ownable = await Ownable.new()
-  })
+  beforeEach(async function() {
+    ownable = await Ownable.new();
+  });
 
-  it('should have an owner', async function () {
-    let owner = await ownable.owner()
-    assert.isTrue(owner !== 0)
-  })
+  it('should have an owner', async function() {
+    let owner = await ownable.owner();
+    assert.isTrue(owner !== 0);
+  });
 
-  it('changes owner after transfer', async function () {
-    let other = accounts[1]
-    await ownable.transferOwnership(other)
-    let owner = await ownable.owner()
+  it('changes owner after transfer', async function() {
+    let other = accounts[1];
+    await ownable.transferOwnership(other);
+    let owner = await ownable.owner();
 
-    assert.isTrue(owner === other)
-  })
+    assert.isTrue(owner === other);
+  });
 
-  it('should prevent non-owners from transfering', async function () {
-    const other = accounts[2]
-    const owner = await ownable.owner.call()
-    assert.isTrue(owner !== other)
+  it('should prevent non-owners from transfering', async function() {
+    const other = accounts[2];
+    const owner = await ownable.owner.call();
+    assert.isTrue(owner !== other);
     try {
-      await ownable.transferOwnership(other, {from: other})
-    } catch (error) {
-      assertJump(error)
+      await ownable.transferOwnership(other, {from: other});
+    } catch(error) {
+      assertJump(error);
     }
-  })
+  });
 
-  it('should guard ownership against stuck state setting owner as 0x0 address', async function () {
-    let originalOwner = await ownable.owner()
+  it('should guard ownership against stuck state', async function() {
+    let originalOwner = await ownable.owner();
     try {
-      await ownable.transferOwnership(null, {from: originalOwner})
-    } catch (error) {
-      assertJump(error)
+      await ownable.transferOwnership(null, {from: originalOwner});
+    } catch(error) {
+      assertJump(error);
     }
-  })
-})
+  });
+
+});

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -38,6 +38,7 @@ contract('Ownable', function(accounts) {
     let originalOwner = await ownable.owner();
     try {
       await ownable.transferOwnership(null, {from: originalOwner});
+      assert.fail()
     } catch(error) {
       assertJump(error);
     }


### PR DESCRIPTION
Fixes #319 

The transfer ownership call in the Ownable contract had a silent failure if the "to" address was not set in the transferOwnership() call.  This fix adds a specific require() call so that any callers of the function will be notified that they passed an incorrect error.