### PR TITLE
Fix test script cleanup and portability

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Executes cleanup function at script exit.
 trap cleanup EXIT

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,8 +4,8 @@
 trap cleanup EXIT
 
 cleanup() {
-  # Kill the testrpc instance that we started (if we started one).
-  if [ -n "$testrpc_pid" ]; then
+  # Kill the testrpc instance that we started (if we started one and if it's still running).
+  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
     kill -9 $testrpc_pid
   fi
 }


### PR DESCRIPTION
This adds a check in the test script to see if the backgrund testrpc instance is running before trying to kill it, so that `kill` doesn't complain that the process isn't running. It comes up when interrupting the tests via `^C` because `SIGINT` also kills the background process.