### PR TITLE
Add missing parentheses in modifier

### DIFF
--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -26,7 +26,7 @@ contract Pausable is Ownable {
   /**
    * @dev modifier to allow actions only when the contract IS NOT paused
    */
-  modifier whenPaused {
+  modifier whenPaused() {
     require(paused);
     _;
   }


### PR DESCRIPTION
The whenPaused modifier was missing the parentheses. Though it was working I added the parentheses for consistency.