### PR TITLE
Upgrade Truffle to 3.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "moment": "^2.18.1",
     "solidity-coverage": "^0.1.7",
-    "truffle": "^3.4.6",
+    "truffle": "^3.4.8",
     "truffle-hdwallet-provider": "0.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3520,9 +3520,9 @@ truffle-hdwallet-provider@0.0.3:
     web3 "^0.18.2"
     web3-provider-engine "^8.4.0"
 
-truffle@^3.4.6:
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-3.4.6.tgz#72a07154233b4d1198ecb991a5fab468a0c54671"
+truffle@^3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-3.4.8.tgz#5d0cc363dfd6eb3fd5efbc9675732b52b587d8c3"
   dependencies:
     mocha "^3.4.2"
     original-require "^1.0.1"


### PR DESCRIPTION
Upgrades Truffle dependency to be at least 3.4.8. (There were some annoying bugs in 3.4.6.)

Updates yarn.lock file accordingly. This affects the travis-ci environment.

I want to wait until #360 is fixed before merging this.