### PR TITLE
Remove token.finishMinting() from default finalization

### DIFF
--- a/contracts/crowdsale/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/FinalizableCrowdsale.sol
@@ -16,8 +16,10 @@ contract FinalizableCrowdsale is Crowdsale, Ownable {
 
   event Finalized();
 
-  // should be called after crowdsale ends, to do
-  // some extra finalization work
+  /**
+   * @dev Must be called after crowdsale ends, to do some extra finalization
+   * work. Calls the contract's finalization function.
+   */
   function finalize() onlyOwner {
     require(!isFinalized);
     require(hasEnded());
@@ -28,12 +30,11 @@ contract FinalizableCrowdsale is Crowdsale, Ownable {
     isFinalized = true;
   }
 
-  // end token minting on finalization
-  // override this with custom logic if needed
+  /**
+   * @dev Can be overriden to add finalization logic. The overriding function
+   * should call super.finalization() to ensure the chain of finalization is
+   * executed entirely.
+   */
   function finalization() internal {
-    token.finishMinting();
   }
-
-
-
 }

--- a/test/FinalizableCrowdsale.js
+++ b/test/FinalizableCrowdsale.js
@@ -60,11 +60,4 @@ contract('FinalizableCrowdsale', function ([_, owner, wallet, thirdparty]) {
     should.exist(event)
   })
 
-  it('finishes minting of token', async function () {
-    await increaseTimeTo(this.afterEndTime)
-    await this.crowdsale.finalize({from: owner})
-    const finished = await this.token.mintingFinished()
-    finished.should.equal(true)
-  })
-
 })

--- a/test/MintableToken.js
+++ b/test/MintableToken.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assertJump = require('./helpers/assertJump');
+import expectThrow from './helpers/expectThrow';
 var MintableToken = artifacts.require('../contracts/Tokens/MintableToken.sol');
 
 contract('Mintable', function(accounts) {
@@ -35,6 +35,12 @@ contract('Mintable', function(accounts) {
     
     let totalSupply = await token.totalSupply();
     assert(totalSupply, 100);
+  })
+
+  it('should fail to mint after call to finishMinting', async function () {
+    await token.finishMinting();
+    assert.equal(await token.mintingFinished(), true);
+    await expectThrow(token.mint(accounts[0], 100));
   })
 
 });


### PR DESCRIPTION
The default `finalization` implementation in `FinalizableCrowdsale` calls `token.finishMinting()`. This is orthogonal to having finalization logic. If one wants to be able to mint further tokens in the future, the default `finalization` function cannot be called. See [decentraland/mana](https://github.com/decentraland/mana/blob/942a4ed9dfedd268805f16c56c5a3b528c33494b/contracts/MANACrowdsale.sol#L175-L176) and how they worked around this:
> cannot call `super.finalization()` here because it would finish minting and the continuous sale would not be able to proceed

Since we want to make sure that all contracts deriving from `FinalizableCrowdsale` call `super.finalization()`, to ensure all of the finalization logic is executed, we have to remove the call to `finishMinting`.


The caveat here is that if a custom finalization transfers ownership of the token to an address, that address will be able to mint tokens unless the custom logic also calls `finishMinting`. This is something that will come up in an audit, however.