### PR TITLE
Make Travis run tests and coverage in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ node_js:
   - "6"
 cache:
   yarn: true
+env:
+  -
+  - SOLIDITY_COVERAGE=true
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: SOLIDITY_COVERAGE=true
 script:
   - yarn test
-after_script:
-  - yarn run coveralls

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,37 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Executes cleanup function at script exit.
-trap cleanup EXIT
-
-cleanup() {
-  # Kill the testrpc instance that we started (if we started one).
-  if [ -n "$testrpc_pid" ]; then
-    kill -9 $testrpc_pid
-  fi
-}
-
-testrpc_running() {
-  nc -z localhost 8555
-}
-
-if testrpc_running; then
-  echo "Using existing testrpc-sc instance"
-else
-  echo "Starting testrpc-sc to generate coverage"
-  # We define 10 accounts with balance 1M ether, needed for high-value tests.
-  ./node_modules/ethereumjs-testrpc-sc/build/cli.node.js --gasLimit 0xfffffffffff --port 8555 \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501202,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501203,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501204,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501205,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501206,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501207,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501208,1000000000000000000000000"  \
-    --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501209,1000000000000000000000000"  \
-  > /dev/null &
-  testrpc_pid=$!
-fi
-
-SOLIDITY_COVERAGE=true ./node_modules/.bin/solidity-coverage
+SOLIDITY_COVERAGE=true scripts/test.sh

--- a/scripts/coveralls.sh
+++ b/scripts/coveralls.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-yarn run coverage && cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-


### PR DESCRIPTION
1. Modified `scripts/test.sh` to run coverage analysis when `SOLIDITY_COVERAGE=true` in the environment. (And to send coverage reports to Coveralls if `CONTINUOUS_INTEGRATION=true`.)
2. Set up a build matrix in Travis CI to run tests and coverage in parallel, and allowed the Travis build to finish as soon as the tests are done.

The Travis build runs in less than half the time now. 🎉

There will be two build jobs now, as shown below. The first one is tests, and the second one is coverage.

![capture-2017-08-14t12 00 q8n7](https://user-images.githubusercontent.com/481465/29281991-791199b6-80f7-11e7-845a-82e3e6ddad0e.png)