### PR TITLE
Add OwnershipTransferred event to Ownable contract and its derivatives

### DIFF
--- a/contracts/ownership/Claimable.sol
+++ b/contracts/ownership/Claimable.sol
@@ -32,8 +32,8 @@ contract Claimable is Ownable {
    * @dev Allows the pendingOwner address to finalize the transfer.
    */
   function claimOwnership() onlyPendingOwner {
+    OwnershipTransferred(owner, pendingOwner);
     owner = pendingOwner;
     pendingOwner = 0x0;
-    OwnershipTransferred(owner);
   }
 }

--- a/contracts/ownership/Claimable.sol
+++ b/contracts/ownership/Claimable.sol
@@ -34,5 +34,6 @@ contract Claimable is Ownable {
   function claimOwnership() onlyPendingOwner {
     owner = pendingOwner;
     pendingOwner = 0x0;
+    OwnershipTransferred(owner);
   }
 }

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -36,6 +36,7 @@ contract DelayedClaimable is Claimable {
     owner = pendingOwner;
     pendingOwner = 0x0;
     end = 0;
+    OwnershipTransferred(owner);
   }
 
 }

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -33,10 +33,10 @@ contract DelayedClaimable is Claimable {
    */
   function claimOwnership() onlyPendingOwner {
     require((block.number <= end) && (block.number >= start));
+    OwnershipTransferred(owner, pendingOwner);
     owner = pendingOwner;
     pendingOwner = 0x0;
     end = 0;
-    OwnershipTransferred(owner);
   }
 
 }

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -38,7 +38,7 @@ contract Ownable {
   function transferOwnership(address newOwner) onlyOwner {
     require(newOwner != address(0));      
     owner = newOwner;
-    OwnershipTransferred(newOwner);
+    OwnershipTransferred(owner, newOwner);
   }
 
 }

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -10,6 +10,9 @@ contract Ownable {
   address public owner;
 
 
+  event OwnershipTransferred(address indexed newOwner);
+
+
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
@@ -35,6 +38,7 @@ contract Ownable {
   function transferOwnership(address newOwner) onlyOwner {
     require(newOwner != address(0));      
     owner = newOwner;
+    OwnershipTransferred(newOwner);
   }
 
 }

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -10,7 +10,7 @@ contract Ownable {
   address public owner;
 
 
-  event OwnershipTransferred(address indexed newOwner);
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
 
   /**

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -37,8 +37,8 @@ contract Ownable {
    */
   function transferOwnership(address newOwner) onlyOwner {
     require(newOwner != address(0));      
-    owner = newOwner;
     OwnershipTransferred(owner, newOwner);
+    owner = newOwner;
   }
 
 }


### PR DESCRIPTION
Me and my team consider this feature very useful at least for debugging purposes, but we also believe it will give more transparency for library users. `OwnershipTransferred` event is being fired each time an ownership transfer really takes place (i.e. in `Ownable.transferOwnership`, `Claimable.claimOwnership` and `DelayedClaimable. Claimable.claimOwnership`).