### PR TITLE
Make approve method compliant with ERC20

### DIFF
--- a/contracts/token/ERC20.sol
+++ b/contracts/token/ERC20.sol
@@ -11,6 +11,6 @@ import './ERC20Basic.sol';
 contract ERC20 is ERC20Basic {
   function allowance(address owner, address spender) constant returns (uint256);
   function transferFrom(address from, address to, uint256 value) returns (bool);
-  function approve(address spender, uint256 value) returns (bool);
+  function approve(address spender, uint256 value) returns (bool success);
   event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -40,6 +40,11 @@ contract StandardToken is ERC20, BasicToken {
 
   /**
    * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   *
+   * Beware that changing an allowance with this method brings the risk that someone may use both the old
+   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */

--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -43,14 +43,7 @@ contract StandardToken is ERC20, BasicToken {
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */
-  function approve(address _spender, uint256 _value) returns (bool) {
-
-    // To change the approve amount you first have to reduce the addresses`
-    //  allowance to zero by calling `approve(_spender, 0)` if it is not
-    //  already 0 to mitigate the race condition described here:
-    //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-    require((_value == 0) || (allowed[msg.sender][_spender] == 0));
-
+  function approve(address _spender, uint256 _value) returns (bool success) {
     allowed[msg.sender][_spender] = _value;
     Approval(msg.sender, _spender, _value);
     return true;


### PR DESCRIPTION
This PR is fixing an issue #438 as we reached the conclusion that it's best to unconditionally follow the [ERC20 specs](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md)