### PR TITLE
fixing typo in `VestedToken.sol` comment

### DIFF
--- a/contracts/token/VestedToken.sol
+++ b/contracts/token/VestedToken.sol
@@ -149,7 +149,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    *   |      .        |
    *   |    .          |
    *   +===+===========+---------+----------> time
-   *      Start       Clift    Vesting
+   *      Start       Cliff    Vesting
    */
   function calculateVestedTokens(
     uint256 tokens,


### PR DESCRIPTION
"Cliff" was misspelled "clift" in a comment.