### PR TITLE
Add `npm init`

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -9,6 +9,7 @@ Zeppelin integrates with `Truffle <https://github.com/ConsenSys/truffle/>`_, an 
 
 To install the Zeppelin library, run::
 
+	npm init # follow instructions
 	npm i zeppelin-solidity
 
 After that, you'll get all the library's contracts in the contracts/zeppelin folder. You can use the contracts in the library like so::


### PR DESCRIPTION
If you don't do this, you'll receive this error:

```
❯ zeppelin npm install zeppelin-solidity
npm WARN saveError ENOENT: no such file or directory, open '/Users/et/package.json'
npm WARN enoent ENOENT: no such file or directory, open '/Users/et/package.json'
npm WARN et No description
npm WARN et No repository field.
npm WARN et No README data
npm WARN et No license field.

+ zeppelin-solidity@1.3.0
updated 1 package in 0.677s
```