### PR TITLE
[SafeMath] Change function modifiers to pure

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -6,25 +6,25 @@ pragma solidity ^0.4.11;
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
-  function mul(uint256 a, uint256 b) internal constant returns (uint256) {
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a * b;
     assert(a == 0 || c / a == b);
     return c;
   }
 
-  function div(uint256 a, uint256 b) internal constant returns (uint256) {
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
     uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
-  function sub(uint256 a, uint256 b) internal constant returns (uint256) {
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
     assert(b <= a);
     return a - b;
   }
 
-  function add(uint256 a, uint256 b) internal constant returns (uint256) {
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a + b;
     assert(c >= a);
     return c;


### PR DESCRIPTION
It is good to have ```constant``` modifier if function does not modify storage. However in this case, it doesn't even read any state information from storage, so it is ```pure```.
Pure is a tightest restriction.

Since last solidity version, compiler started to warnings about this:
"SafeMath.sol:15:3: Warning: Function state mutability can be restricted to pure"