### PR TITLE
Updates to token vesting contract

### DIFF
--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -25,6 +25,7 @@ contract TokenVesting is Ownable {
   uint256 public duration;
 
   bool public revocable;
+  bool public revoked;
 
   uint256 public released;
 
@@ -111,12 +112,13 @@ contract TokenVesting is Ownable {
    */
   function revoke() onlyOwner public {
     require(revocable);
+    require(!revoked);
 
     uint256 balance = token.balanceOf(this);
     uint256 vested = vestedAmount();
+    revoked = true;
 
     token.transfer(owner, balance - vested);
-    token.transfer(beneficiary, vested);
 
     Revoked();
   }
@@ -129,7 +131,7 @@ contract TokenVesting is Ownable {
 
       return 0;
 
-    } else if (now >= start + duration) {
+    } else if (now >= start + duration || revoked) {
 
       return token.balanceOf(this);
 

--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.11;
 
-import './ERC20Basic.sol';
+import './ERC20.sol';
 import '../ownership/Ownable.sol';
 import '../math/Math.sol';
 import '../math/SafeMath.sol';
@@ -28,7 +28,7 @@ contract TokenVesting is Ownable {
 
   uint256 public released;
 
-  ERC20Basic public token;
+  ERC20 public token;
 
   /**
    * @dev Creates a vesting contract that vests its balance of any ERC20 token to the
@@ -56,7 +56,7 @@ contract TokenVesting is Ownable {
     cliff       = _start + _cliff;
     duration    = _duration;
     revocable   = _revocable;
-    token       = ERC20Basic(_token);
+    token       = ERC20(_token);
   }
 
   /**
@@ -131,7 +131,11 @@ contract TokenVesting is Ownable {
     }
   }
 
-  function () payable public {
-    revert();
+  /**
+   * @notice Allow withdrawing any token other than the relevant one
+   */
+  function releaseToken(ERC20 _token, uint256 amount) onlyOwner {
+    require(_token != token);
+    _token.transfer(owner, amount);
   }
 }

--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -71,13 +71,28 @@ contract TokenVesting is Ownable {
    * @notice Transfers vested tokens to beneficiary.
    */
   function release() onlyBeneficiary public {
+    _releaseTo(beneficiary);
+  }
+
+  /**
+   * @notice Transfers vested tokens to a target address.
+   * @param target the address to send the tokens to
+   */
+  function releaseTo(address target) onlyBeneficiary public {
+    _releaseTo(target);
+  }
+
+  /**
+   * @notice Transfers vested tokens to beneficiary.
+   */
+  function _releaseTo(address target) internal {
     uint256 vested = vestedAmount();
 
     require(vested > 0);
 
     released = released.add(vested);
 
-    token.transfer(beneficiary, vested);
+    token.transfer(target, vested);
 
     Released(vested);
   }

--- a/test/TokenVesting.js
+++ b/test/TokenVesting.js
@@ -52,6 +52,16 @@ contract('TokenVesting', function ([_, owner, beneficiary, unknown, thirdParty])
     balance.should.bignumber.equal(amount.mul(releaseTime - this.start).div(this.duration).floor());
   });
 
+  it('should allow the beneficiary to transfer tokens to another address', async function () {
+    await increaseTimeTo(this.start + this.cliff);
+
+    const { receipt } = await this.vesting.releaseTo(thirdParty, { from: beneficiary });
+    const releaseTime = web3.eth.getBlock(receipt.blockNumber).timestamp;
+
+    const balance = await this.token.balanceOf(thirdParty);
+    balance.should.bignumber.equal(amount.mul(releaseTime - this.start).div(this.duration).floor());
+  });
+
   it('should linearly release tokens during vesting period', async function () {
     const vestingPeriod = this.duration - this.cliff;
     const checkpoints = 4;

--- a/test/TokenVesting.js
+++ b/test/TokenVesting.js
@@ -132,4 +132,14 @@ contract('TokenVesting', function ([_, owner, beneficiary, unknown, thirdParty])
   it('should prevent beneficiary change to the null address', async function () {
     await this.vesting.changeBeneficiary(0, { from: beneficiary }).should.be.rejectedWith(EVMThrow);
   });
+
+  it('allows withdraws of tokens other than the one vested', async function () {
+    const amount = 100
+    const token2 = await MintableToken.new({ from: owner });
+    await token2.mint(this.vesting.address, amount, { from: owner });
+    await this.vesting.releaseToken(token2.address, amount, { from: owner });
+
+    const balance = await token2.balanceOf(owner);
+    balance.should.bignumber.equal(amount);
+  });
 });


### PR DESCRIPTION
Changes:
- Fixes revoke() as described in https://github.com/OpenZeppelin/zeppelin-solidity/pull/492
- Drop the mapping to work with different tokens
- Make the beneficiary transferable
- Prevent anyone from releasing the tokens except for the beneficiary
- Handle other tokens sent to the contract by error
- Allow release to a different address