### PR TITLE
[TokenVesting] vestedAmount should return the historical vested amount

### DIFF
--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -47,7 +47,7 @@ contract TokenVesting is Ownable {
     beneficiary = _beneficiary;
     revocable = _revocable;
     duration = _duration;
-    cliff = _start + _cliff;
+    cliff = _start.add(_cliff);
     start = _start;
   }
 

--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -56,7 +56,6 @@ contract TokenVesting is Ownable {
    * @param token ERC20 token which is being vested
    */
   function release(ERC20Basic token) public {
-    uint256 vested = vestedAmount(token);
     uint256 unreleased = releasableAmount(token);
 
     require(unreleased > 0);

--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -61,9 +61,9 @@ contract TokenVesting is Ownable {
 
     require(unreleased > 0);
 
-    token.safeTransfer(beneficiary, unreleased);
-
     released[token] = released[token].add(unreleased);
+
+    token.safeTransfer(beneficiary, unreleased);
 
     Released(unreleased);
   }

--- a/test/TokenVesting.js
+++ b/test/TokenVesting.js
@@ -83,12 +83,11 @@ contract('TokenVesting', function ([_, owner, beneficiary]) {
     await increaseTimeTo(this.start + this.cliff + duration.weeks(12));
 
     const vested = await this.vesting.vestedAmount(this.token.address);
-    const balance = await this.token.balanceOf(this.vesting.address);
 
     await this.vesting.revoke(this.token.address, { from: owner });
 
     const ownerBalance = await this.token.balanceOf(owner);
-    ownerBalance.should.bignumber.equal(balance.sub(vested));
+    ownerBalance.should.bignumber.equal(amount.sub(vested));
   });
 
   it('should keep the vested tokens when revoked by owner', async function () {


### PR DESCRIPTION
This new implementation respects the `vestedAmount` method name by returning the total vested and not the `unreleasedAmount`, for which I added a new getter enabling an easier usage and better interpretation of the vesting information.

This change also replaces contract's balance with initial minted amount of tokens as source of truth when testing for proper refund in a revocation event, as the former might have changed in case of a previous release.

This PR also includes a few SafeMath operations that were missing.