### PR TITLE
Finish minting should be called only once

### DIFF
--- a/contracts/token/MintableToken.sol
+++ b/contracts/token/MintableToken.sol
@@ -43,7 +43,7 @@ contract MintableToken is StandardToken, Ownable {
    * @dev Function to stop minting new tokens.
    * @return True if the operation was successful.
    */
-  function finishMinting() onlyOwner public returns (bool) {
+  function finishMinting() onlyOwner canMint public returns (bool) {
     mintingFinished = true;
     MintFinished();
     return true;


### PR DESCRIPTION
Multiple calls to `finishMinting` will emit multiple `MintFinished` events which may be surprising if one rely on `MintFinished` event.