### PR TITLE
Replace deprecated throw with assert in Solidity tests

### DIFF
--- a/test/helpers/ReentrancyAttack.sol
+++ b/test/helpers/ReentrancyAttack.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.4.11;
 contract ReentrancyAttack {
 
   function callSender(bytes4 data) {
-    if(!msg.sender.call(data)) {
-      throw;
-    }
+    assert(msg.sender.call(data));
   }
 
 }

--- a/test/helpers/ReentrancyAttack.sol
+++ b/test/helpers/ReentrancyAttack.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.11;
 contract ReentrancyAttack {
 
   function callSender(bytes4 data) {
-    assert(msg.sender.call(data));
+    require(msg.sender.call(data));
   }
 
 }

--- a/test/helpers/ReentrancyMock.sol
+++ b/test/helpers/ReentrancyMock.sol
@@ -27,9 +27,7 @@ contract ReentrancyMock is ReentrancyGuard {
     if(n > 0) {
       count();
       bool result = this.call(func, n - 1);
-      if(result != true) {
-        throw;
-      }
+      assert(result == true);
     }
   }
 

--- a/test/helpers/ReentrancyMock.sol
+++ b/test/helpers/ReentrancyMock.sol
@@ -27,7 +27,7 @@ contract ReentrancyMock is ReentrancyGuard {
     if(n > 0) {
       count();
       bool result = this.call(func, n - 1);
-      assert(result == true);
+      require(result == true);
     }
   }
 


### PR DESCRIPTION
Both `test/helpers/ReentrancyAttack.sol` and `test/helpers/ReentrancyMock.sol` used `throw` which has been deprecated since 0.4.13

Replacing them with `assert`s removes the two ugly error messages that have plagued the tests https://travis-ci.org/OpenZeppelin/zeppelin-solidity/jobs/289039499#L535