### PR TITLE
HasNoEther don't need to be `payable` to act as expected

### DIFF
--- a/contracts/ownership/HasNoEther.sol
+++ b/contracts/ownership/HasNoEther.sol
@@ -16,12 +16,10 @@ contract HasNoEther is Ownable {
 
   /**
   * @dev Constructor that rejects incoming Ether
-  * @dev The `payable` flag is added so we can access `msg.value` without compiler warning. If we
-  * leave out payable, then Solidity will allow inheriting contracts to implement a payable
-  * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
-  * we could use assembly to access msg.value.
+  * @dev Check that value associated to the transcation is 0 to prevent a payable constructor from 
+  * working. A warning from Solidity compiler is expected at this point.
   */
-  function HasNoEther() payable {
+  function HasNoEther() {
     require(msg.value == 0);
   }
 


### PR DESCRIPTION
I checked the unit test and all works as expected. I also did some test with remix, and again there's no problem to let out the `payable` modifier.