### PR TITLE
Create CappedToken, a capped MintableToken

### DIFF
--- a/contracts/token/CappedToken.sol
+++ b/contracts/token/CappedToken.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.4.11;
+
+import './MintableToken.sol';
+
+/**
+ * @title Capped token
+ * @dev Mintable token with a token cap.
+ */
+
+contract CappedToken is MintableToken {
+
+  uint256 public cap;
+
+  function CappedToken(uint256 _cap) {
+    require(_cap > 0);
+    cap = _cap;
+  }
+
+  /**
+   * @dev Function to mint tokens
+   * @param _to The address that will receive the minted tokens.
+   * @param _amount The amount of tokens to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function mint(address _to, uint256 _amount) onlyOwner canMint public returns (bool) {
+    require(totalSupply.add(_amount) <= cap);
+
+    return MintableToken.mint(_to, _amount);
+  }
+
+}

--- a/contracts/token/CappedToken.sol
+++ b/contracts/token/CappedToken.sol
@@ -25,7 +25,7 @@ contract CappedToken is MintableToken {
   function mint(address _to, uint256 _amount) onlyOwner canMint public returns (bool) {
     require(totalSupply.add(_amount) <= cap);
 
-    return MintableToken.mint(_to, _amount);
+    return super.mint(_to, _amount);
   }
 
 }

--- a/test/CappedToken.js
+++ b/test/CappedToken.js
@@ -1,0 +1,39 @@
+'use strict';
+
+import expectThrow from './helpers/expectThrow';
+import ether from './helpers/ether';
+var CappedToken = artifacts.require('../contracts/Tokens/CappedToken.sol');
+
+const BigNumber = web3.BigNumber
+
+contract('Capped', function(accounts) {
+  const cap = ether(1000);
+
+  let token;
+
+  beforeEach(async function() {
+    token = await CappedToken.new(cap);
+  })
+
+  it('should start with the correct cap', async function() {
+    let _cap = await token.cap();
+
+    assert.equal(cap.toNumber(), _cap.toNumber());
+  })
+
+  it('should mint when amount does amount does not exceed the cap', async function() {
+    const result = await token.mint(accounts[0], 100);
+    assert.equal(result.logs[0].event, 'Mint');
+  })
+
+  it('should fail to mint if the ammount exceeds the cap', async function() {
+    await token.mint(accounts[0], cap.sub(1));
+    await expectThrow(token.mint(accounts[0], 100));
+  })
+
+  it('should fail to mint after cap is reached', async function() {
+    await token.mint(accounts[0], cap);
+    await expectThrow(token.mint(accounts[0], 1));
+  })
+
+});

--- a/test/CappedToken.js
+++ b/test/CappedToken.js
@@ -21,7 +21,7 @@ contract('Capped', function(accounts) {
     assert.equal(cap.toNumber(), _cap.toNumber());
   })
 
-  it('should mint when amount does amount does not exceed the cap', async function() {
+  it('should mint when amount is less than cap', async function() {
     const result = await token.mint(accounts[0], 100);
     assert.equal(result.logs[0].event, 'Mint');
   })


### PR DESCRIPTION
This PR implements CappedToken, a capped MintableToken. This token will allow tokens to be minted up until the cap is reached.