### PR TITLE
Check for revert in expectThrow

### DIFF
--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -10,8 +10,13 @@ export default async promise => {
     //       we distinguish this from an actual out of gas event? (The
     //       testrpc log actually show an 'invalid jump' event.)
     const outOfGas = error.message.search('out of gas') >= 0;
+    // Check for revert opcode. As of the Byzantium hardfork, contracts
+    // that use the 'require' guard or call 'revert' will use the revert opcode to stop exection upon error,
+    // rollback contract state changes during the transaction and return gas to the sender.
+    const revert = error.message.search('revert') >= 0;
+
     assert(
-      invalidOpcode || outOfGas,
+      invalidOpcode || outOfGas || revert,
       "Expected throw, got '" + error + "' instead",
     );
     return;


### PR DESCRIPTION
Added a check for revert in the error message in `expectThrow.js`. I've been using this with ethereumjs-testrpc v5.0.1@beta which includes the Byzantium changes in order to handle contract errors that are caused by the new revert opcode.