### PR TITLE
Make token transfer extensible in crowdsale

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -78,10 +78,17 @@ contract Crowdsale {
     // update state
     weiRaised = weiRaised.add(weiAmount);
 
-    token.mint(beneficiary, tokens);
+    transferToken(beneficiary, tokens);
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
 
     forwardFunds();
+  }
+  
+  // low level token transfer function
+  // override to create custom token transfer mechanism
+  // eg. pull pattern to save gas during contribution period when congestion is more likely
+  function transferToken(address beneficiary, uint256 tokens) internal {
+    token.mint(beneficiary, tokens);
   }
 
   // send ether to the fund collection wallet


### PR DESCRIPTION
Add a dedicated tokenTransfer internal function, which can be used to create flexible token transfer mechanisms, like:
- pull pattern: during crowdsale there is no minting, which reduces gas costs during a high congestion period, and make it possible to withdraw tokens after finalization
- trust fund like crowdsale: it doesn't mint but transfers its own tokens, when tokens are premined