### PR TITLE
Updated mul() and div() methods.

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -8,15 +8,15 @@ pragma solidity ^0.4.11;
 library SafeMath {
   function mul(uint256 a, uint256 b) internal constant returns (uint256) {
     uint256 c = a * b;
-    assert(a == 0 || c / a == b);
+    assert(c / a == b); // Solidity automatically throws when dividing by 0
     return c;
   }
 
   function div(uint256 a, uint256 b) internal constant returns (uint256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
-    uint256 c = a / b;
+    // uint256 c = a / b; // Wasting gas to allocate memory for uint256
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-    return c;
+    return a / b;
   }
 
   function sub(uint256 a, uint256 b) internal constant returns (uint256) {


### PR DESCRIPTION
Reason: fix gas wasting for useless local variable, get rid of useless assertion