### PR TITLE
Changing the ownership in two stages

### DIFF
--- a/contracts/ownership/HasNoContracts.sol
+++ b/contracts/ownership/HasNoContracts.sol
@@ -11,6 +11,15 @@ import "./Ownable.sol";
 contract HasNoContracts is Ownable {
 
   /**
+   * @dev Claim ownership of Ownable contracts
+   * @param contractAddr The address of the Ownable to be claimed.
+   */
+  function claimContract(address contractAddr) external onlyOwner {
+    Ownable contractInst = Ownable(contractAddr);
+    contractInst.takeOwnership();
+  }
+
+  /**
    * @dev Reclaim ownership of Ownable contracts
    * @param contractAddr The address of the Ownable to be reclaimed.
    */

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -8,10 +8,10 @@ pragma solidity ^0.4.11;
  */
 contract Ownable {
   address public owner;
+  address public transferOwnershipAddress;
 
-
+  event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
   event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
 
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
@@ -33,12 +33,25 @@ contract Ownable {
 
   /**
    * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * Note that current owner still have control until new owner accept the transfer
+   * with call of takeOwnership() to complete the operation.
    * @param newOwner The address to transfer ownership to.
    */
   function transferOwnership(address newOwner) onlyOwner public {
     require(newOwner != address(0));
-    OwnershipTransferred(owner, newOwner);
-    owner = newOwner;
+    OwnershipTransferStarted(owner, newOwner);
+    transferOwnershipAddress = newOwner;
+  }
+
+  /**
+   * @dev Allows the new owner to take the control of the contract.
+   */
+  function takeOwnership() public {
+    require(transferOwnershipAddress != address(0));
+    require(msg.sender == transferOwnershipAddress);
+    OwnershipTransferred(owner, transferOwnershipAddress);
+    owner = transferOwnershipAddress;
+    transferOwnershipAddress = address(0);
   }
 
 }

--- a/test/HasNoContracts.js
+++ b/test/HasNoContracts.js
@@ -17,6 +17,7 @@ contract('HasNoContracts', function(accounts) {
 
     // Force ownership into contract
     await ownable.transferOwnership(hasNoContracts.address);
+    await ownable.takeOwnership({from: hasNoContracts.address});
     const owner = await ownable.owner();
     assert.equal(owner, hasNoContracts.address);
   });

--- a/test/HasNoContracts.js
+++ b/test/HasNoContracts.js
@@ -24,6 +24,7 @@ contract('HasNoContracts', function(accounts) {
 
   it('should allow owner to reclaim contracts', async function() {
     await hasNoContracts.reclaimContract(ownable.address);
+    await ownable.takeOwnership();
     const owner = await ownable.owner();
     assert.equal(owner, accounts[0]);
   });

--- a/test/HasNoContracts.js
+++ b/test/HasNoContracts.js
@@ -17,7 +17,7 @@ contract('HasNoContracts', function(accounts) {
 
     // Force ownership into contract
     await ownable.transferOwnership(hasNoContracts.address);
-    await ownable.takeOwnership({from: hasNoContracts.address});
+    await hasNoContracts.claimContract(ownable.address);
     const owner = await ownable.owner();
     assert.equal(owner, hasNoContracts.address);
   });

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -15,12 +15,17 @@ contract('Ownable', function(accounts) {
     assert.isTrue(owner !== 0);
   });
 
-  it('changes owner after transfer', async function() {
+  it('changes owner after transfer and take', async function() {
     let other = accounts[1];
-    await ownable.transferOwnership(other);
-    let owner = await ownable.owner();
+    const owner = await ownable.owner.call();
 
-    assert.isTrue(owner === other);
+    await ownable.transferOwnership(other);
+    let owner1 = await ownable.owner();
+    assert.isTrue(owner1 === owner);
+
+    await ownable.takeOwnership({from: other});
+    let owner2 = await ownable.owner();
+    assert.isTrue(owner2 === other);
   });
 
   it('should prevent non-owners from transfering', async function() {


### PR DESCRIPTION
At the moment the ownership transfer is one of most dangerous operations.

It is better to do this in two stages:

1. existing owner start ownership transfer, 
2. new owner has to confirm ownership change by calling takeOwnership. 

This process makes the process of changing the ownership more safe as the operation requires actions from both sides. 

Also this performs that new owner is available to do api calls, so private keys are not lost, new owner is not dead, operable and is humanoid bipedal being or if the transfers of the ownership happens to another smart contract it gives some prove about this smart contract logic to be able to communicate with this one. 

For existing owner it provides some time gap to revert the transfer process if it happens by mistake or provided wrong address for transfer.