### PR TITLE
added versions output to Travis CI log #534

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: SOLIDITY_COVERAGE=true
+before_script:
+  - truffle version
+  - yarn list
 script:
   - yarn test
 notifications:


### PR DESCRIPTION
Added versions info output to TravisCI log (issue #534)
folded by default
![image](https://user-images.githubusercontent.com/19608867/32690037-a68c9036-c700-11e7-8d44-b5dbeff4beb4.png)

