### PR TITLE
Solium run and Solium version update

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,22 +1,10 @@
 {
-  "custom-rules-filename": null,
+  "extends": "solium:all",
+  "plugins": ["security"],
   "rules": {
-    "imports-on-top": true,
-    "variable-declarations": true,
-    "array-declarations": true,
-    "operator-whitespace": true,
-    "lbrace": true,
-    "mixedcase": false,
-    "camelcase": true,
-    "uppercase": true,
-    "no-with": true,
-    "no-empty-blocks": true,
-    "no-unused-vars": true,
-    "double-quotes": true,
-    "blank-lines": true,
-    "indentation": true,
-    "whitespace": true,
-    "deprecated-suicide": true,
-    "pragma-on-top": true
+    "indentation": ["error", 2],
+    "quotes": ["error", "double"],
+    "security/enforce-explicit-visibility": ["error"],
+    "security/no-block-members": ["warning", ["timestamp"]]
   }
 }

--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -18,7 +18,7 @@ contract Bounty is PullPayment, Destructible {
   /**
    * @dev Fallback function allowing the contract to receive funds, if they haven't already been claimed.
    */
-  function() payable {
+  function() public payable {
     require(!claimed);
   }
 

--- a/contracts/DayLimit.sol
+++ b/contracts/DayLimit.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.11;
 
+
 /**
  * @title DayLimit
  * @dev Base contract that enables methods to be protected by placing a linear limit (specifiable)
@@ -15,7 +16,7 @@ contract DayLimit {
    * @dev Constructor that sets the passed value as a dailyLimit.
    * @param _limit uint256 to represent the daily limit.
    */
-  function DayLimit(uint256 _limit) {
+  function DayLimit(uint256 _limit) internal {
     dailyLimit = _limit;
     lastDay = today();
   }

--- a/contracts/LimitBalance.sol
+++ b/contracts/LimitBalance.sol
@@ -15,7 +15,7 @@ contract LimitBalance {
    * @dev Constructor that sets the passed value as a limit.
    * @param _limit uint256 to represent the limit.
    */
-  function LimitBalance(uint256 _limit) {
+  function LimitBalance(uint256 _limit) internal {
     limit = _limit;
   }
 

--- a/contracts/MerkleProof.sol
+++ b/contracts/MerkleProof.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.11;
 
+
 /*
  * @title MerkleProof
  * @dev Merkle proof verification
@@ -13,9 +14,19 @@ library MerkleProof {
    * @param _root Merkle root
    * @param _leaf Leaf of Merkle tree
    */
-  function verifyProof(bytes _proof, bytes32 _root, bytes32 _leaf) constant returns (bool) {
+
+  function verifyProof(
+    bytes _proof,
+    bytes32 _root,
+    bytes32 _leaf
+  )
+    public
+    constant
+    returns (bool)
+  {
     // Check if proof length is a multiple of 32
-    if (_proof.length % 32 != 0) return false;
+    if (_proof.length % 32 != 0)
+      return false;
 
     bytes32 proofElement;
     bytes32 computedHash = _leaf;

--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.11;
 
+
 /**
  * @title Helps contracts guard agains rentrancy attacks.
  * @author Remco Bloemen <remco@2π.com>

--- a/contracts/crowdsale/CappedCrowdsale.sol
+++ b/contracts/crowdsale/CappedCrowdsale.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.11;
 import '../math/SafeMath.sol';
 import './Crowdsale.sol';
 
+
 /**
  * @title CappedCrowdsale
  * @dev Extension of Crowdsale with a max amount of funds raised
@@ -12,7 +13,7 @@ contract CappedCrowdsale is Crowdsale {
 
   uint256 public cap;
 
-  function CappedCrowdsale(uint256 _cap) {
+  function CappedCrowdsale(uint256 _cap) internal {
     require(_cap > 0);
     cap = _cap;
   }

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -50,7 +50,9 @@ contract Crowdsale {
     uint256 _endTime,
     uint256 _rate,
     address _wallet
-  ) {
+  )
+    public
+  {
     require(_startTime >= now);
     require(_endTime >= _startTime);
     require(_rate > 0);

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -50,9 +50,7 @@ contract Crowdsale {
     uint256 _endTime,
     uint256 _rate,
     address _wallet
-  )
-    internal
-  {
+  ) {
     require(_startTime >= now);
     require(_endTime >= _startTime);
     require(_rate > 0);

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.11;
 import '../token/MintableToken.sol';
 import '../math/SafeMath.sol';
 
+
 /**
  * @title Crowdsale
  * @dev Crowdsale is a base contract for managing a token crowdsale.
@@ -37,10 +38,21 @@ contract Crowdsale {
    * @param value weis paid for purchase
    * @param amount amount of tokens purchased
    */
-  event TokenPurchase(address indexed purchaser, address indexed beneficiary, uint256 value, uint256 amount);
+  event TokenPurchase(
+    address indexed purchaser,
+    address indexed beneficiary,
+    uint256 value,
+    uint256 amount
+  );
 
-
-  function Crowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, address _wallet) {
+  function Crowdsale(
+    uint256 _startTime,
+    uint256 _endTime,
+    uint256 _rate,
+    address _wallet
+  )
+    internal
+  {
     require(_startTime >= now);
     require(_endTime >= _startTime);
     require(_rate > 0);
@@ -59,9 +71,8 @@ contract Crowdsale {
     return new MintableToken();
   }
 
-
   // fallback function can be used to buy tokens
-  function () payable {
+  function () public payable {
     buyTokens(msg.sender);
   }
 

--- a/contracts/crowdsale/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/FinalizableCrowdsale.sol
@@ -4,6 +4,7 @@ import '../math/SafeMath.sol';
 import '../ownership/Ownable.sol';
 import './Crowdsale.sol';
 
+
 /**
  * @title FinalizableCrowdsale
  * @dev Extension of Crowdsale where an owner can do extra work

--- a/contracts/crowdsale/RefundVault.sol
+++ b/contracts/crowdsale/RefundVault.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.11;
 import '../math/SafeMath.sol';
 import '../ownership/Ownable.sol';
 
+
 /**
  * @title RefundVault
  * @dev This contract is used for storing funds while a crowdsale
@@ -22,7 +23,7 @@ contract RefundVault is Ownable {
   event RefundsEnabled();
   event Refunded(address indexed beneficiary, uint256 weiAmount);
 
-  function RefundVault(address _wallet) {
+  function RefundVault(address _wallet) public {
     require(_wallet != 0x0);
     wallet = _wallet;
     state = State.Active;

--- a/contracts/crowdsale/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/RefundableCrowdsale.sol
@@ -21,7 +21,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
   // refund vault used to hold funds while crowdsale is running
   RefundVault public vault;
 
-  function RefundableCrowdsale(uint256 _goal) {
+  function RefundableCrowdsale(uint256 _goal) public {
     require(_goal > 0);
     vault = new RefundVault(wallet);
     goal = _goal;

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -4,6 +4,7 @@ import "../crowdsale/CappedCrowdsale.sol";
 import "../crowdsale/RefundableCrowdsale.sol";
 import "../token/MintableToken.sol";
 
+
 /**
  * @title SampleCrowdsaleToken
  * @dev Very simple ERC20 Token that can be minted.
@@ -11,11 +12,12 @@ import "../token/MintableToken.sol";
  */
 contract SampleCrowdsaleToken is MintableToken {
 
-  string public constant name = "Sample Crowdsale Token";
-  string public constant symbol = "SCT";
-  uint8 public constant decimals = 18;
+  string public constant NAME = "Sample Crowdsale Token";
+  string public constant SYMBOL = "SCT";
+  uint8 public constant DECIMALS = 18;
 
 }
+
 
 /**
  * @title SampleCrowdsale
@@ -30,7 +32,15 @@ contract SampleCrowdsaleToken is MintableToken {
  */
 contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
 
-  function SampleCrowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, uint256 _goal, uint256 _cap, address _wallet)
+  function SampleCrowdsale(
+    uint256 _startTime,
+    uint256 _endTime,
+    uint256 _rate,
+    uint256 _goal,
+    uint256 _cap,
+    address _wallet
+  )
+    public
     CappedCrowdsale(_cap)
     FinalizableCrowdsale()
     RefundableCrowdsale(_goal)

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -12,16 +12,16 @@ import "../token/StandardToken.sol";
  */
 contract SimpleToken is StandardToken {
 
-  string public constant name = "SimpleToken";
-  string public constant symbol = "SIM";
-  uint8 public constant decimals = 18;
+  string public constant NAME = "SimpleToken";
+  string public constant SYMBOL = "SIM";
+  uint8 public constant DECIMALS = 18;
 
-  uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(decimals));
+  uint256 public constant INITIAL_SUPPLY = 10000 * (10 ** uint256(DECIMALS));
 
   /**
    * @dev Constructor that gives msg.sender all of existing tokens.
    */
-  function SimpleToken() {
+  function SimpleToken() public {
     totalSupply = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
   }

--- a/contracts/lifecycle/Destructible.sol
+++ b/contracts/lifecycle/Destructible.sol
@@ -10,7 +10,7 @@ import "../ownership/Ownable.sol";
  */
 contract Destructible is Ownable {
 
-  function Destructible() payable { }
+  function Destructible() internal payable { }
 
   /**
    * @dev Transfers the current balance to the owner and terminates the contract.

--- a/contracts/lifecycle/Destructible.sol
+++ b/contracts/lifecycle/Destructible.sol
@@ -10,7 +10,7 @@ import "../ownership/Ownable.sol";
  */
 contract Destructible is Ownable {
 
-  function Destructible() internal payable { }
+  function Destructible() public payable { }
 
   /**
    * @dev Transfers the current balance to the owner and terminates the contract.

--- a/contracts/lifecycle/Migrations.sol
+++ b/contracts/lifecycle/Migrations.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.11;
 
 import '../ownership/Ownable.sol';
 
+
 /**
  * @title Migrations
  * @dev This is a truffle contract, needed for truffle integration, not meant for use by Zeppelin users.

--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -13,7 +13,7 @@ import "../token/ERC20Basic.sol";
  */
 contract TokenDestructible is Ownable {
 
-  function TokenDestructible() internal payable { }
+  function TokenDestructible() public payable { }
 
   /**
    * @notice Terminate contract and refund to owner

--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.4.11;
 import "../ownership/Ownable.sol";
 import "../token/ERC20Basic.sol";
 
+
 /**
  * @title TokenDestructible:
  * @author Remco Bloemen <remco@2π.com>
@@ -12,7 +13,7 @@ import "../token/ERC20Basic.sol";
  */
 contract TokenDestructible is Ownable {
 
-  function TokenDestructible() payable { }
+  function TokenDestructible() internal payable { }
 
   /**
    * @notice Terminate contract and refund to owner
@@ -24,7 +25,7 @@ contract TokenDestructible is Ownable {
   function destroy(address[] tokens) onlyOwner public {
 
     // Transfer tokens to owner
-    for(uint256 i = 0; i < tokens.length; i++) {
+    for (uint256 i = 0; i < tokens.length; i++) {
       ERC20Basic token = ERC20Basic(tokens[i]);
       uint256 balance = token.balanceOf(this);
       token.transfer(owner, balance);

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.4.11;
 
+
 /**
  * @title Math
  * @dev Assorted math operations
  */
-
 library Math {
   function max64(uint64 a, uint64 b) internal constant returns (uint64) {
     return a >= b ? a : b;

--- a/contracts/ownership/CanReclaimToken.sol
+++ b/contracts/ownership/CanReclaimToken.sol
@@ -4,6 +4,7 @@ import "./Ownable.sol";
 import "../token/ERC20Basic.sol";
 import "../token/SafeERC20.sol";
 
+
 /**
  * @title Contracts that should be able to recover tokens
  * @author SylTi

--- a/contracts/ownership/Contactable.sol
+++ b/contracts/ownership/Contactable.sol
@@ -2,20 +2,21 @@ pragma solidity ^0.4.11;
 
 import './Ownable.sol';
 
+
 /**
  * @title Contactable token
  * @dev Basic version of a contactable contract, allowing the owner to provide a string with their
  * contact information.
  */
-contract Contactable is Ownable{
+contract Contactable is Ownable {
 
-    string public contactInformation;
+  string public contactInformation;
 
-    /**
-     * @dev Allows the owner to set a string with their contact information.
-     * @param info The contact information to attach to the contract.
-     */
-    function setContactInformation(string info) onlyOwner public {
-         contactInformation = info;
-     }
+  /**
+   * @dev Allows the owner to set a string with their contact information.
+   * @param info The contact information to attach to the contract.
+   */
+  function setContactInformation(string info) onlyOwner public {
+    contactInformation = info;
+  }
 }

--- a/contracts/ownership/DelayedClaimable.sol
+++ b/contracts/ownership/DelayedClaimable.sol
@@ -26,7 +26,6 @@ contract DelayedClaimable is Claimable {
     start = _start;
   }
 
-
   /**
    * @dev Allows the pendingOwner address to finalize the transfer, as long as it is called within
    * the specified start and end time.

--- a/contracts/ownership/HasNoContracts.sol
+++ b/contracts/ownership/HasNoContracts.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "./Ownable.sol";
 
+
 /**
  * @title Contracts that should not own Contracts
  * @author Remco Bloemen <remco@2π.com>

--- a/contracts/ownership/HasNoEther.sol
+++ b/contracts/ownership/HasNoEther.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "./Ownable.sol";
 
+
 /**
  * @title Contracts that should not own Ether
  * @author Remco Bloemen <remco@2π.com>
@@ -21,7 +22,7 @@ contract HasNoEther is Ownable {
   * constructor. By doing it this way we prevent a payable constructor from working. Alternatively
   * we could use assembly to access msg.value.
   */
-  function HasNoEther() payable {
+  function HasNoEther() internal payable {
     require(msg.value == 0);
   }
 

--- a/contracts/ownership/HasNoTokens.sol
+++ b/contracts/ownership/HasNoTokens.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "./CanReclaimToken.sol";
 
+
 /**
  * @title Contracts that should not own Tokens
  * @author Remco Bloemen <remco@2π.com>

--- a/contracts/ownership/NoOwner.sol
+++ b/contracts/ownership/NoOwner.sol
@@ -4,6 +4,7 @@ import "./HasNoEther.sol";
 import "./HasNoTokens.sol";
 import "./HasNoContracts.sol";
 
+
 /**
  * @title Base contract for contracts that should not own things.
  * @author Remco Bloemen <remco@2π.com>

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -9,18 +9,15 @@ pragma solidity ^0.4.11;
 contract Ownable {
   address public owner;
 
-
   event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
 
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender
    * account.
    */
-  function Ownable() {
+  function Ownable() public {
     owner = msg.sender;
   }
-
 
   /**
    * @dev Throws if called by any account other than the owner.
@@ -29,7 +26,6 @@ contract Ownable {
     require(msg.sender == owner);
     _;
   }
-
 
   /**
    * @dev Allows the current owner to transfer control of the contract to a newOwner.

--- a/contracts/payment/SplitPayment.sol
+++ b/contracts/payment/SplitPayment.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import '../math/SafeMath.sol';
 
+
 /**
  * @title SplitPayment
  * @dev Base contract that supports multiple payees claiming funds sent to this contract 
@@ -20,7 +21,7 @@ contract SplitPayment {
   /**
    * @dev Constructor
    */
-  function SplitPayment(address[] _payees, uint256[] _shares) {
+  function SplitPayment(address[] _payees, uint256[] _shares) internal {
     require(_payees.length == _shares.length);
 
     for (uint256 i = 0; i < _payees.length; i++) {

--- a/contracts/token/BurnableToken.sol
+++ b/contracts/token/BurnableToken.sol
@@ -2,27 +2,28 @@ pragma solidity ^0.4.13;
 
 import './StandardToken.sol';
 
+
 /**
  * @title Burnable Token
  * @dev Token that can be irreversibly burned (destroyed).
  */
 contract BurnableToken is StandardToken {
 
-    event Burn(address indexed burner, uint256 value);
+  event Burn(address indexed burner, uint256 value);
 
-    /**
-     * @dev Burns a specific amount of tokens.
-     * @param _value The amount of token to be burned.
-     */
-    function burn(uint256 _value) public {
-        require(_value > 0);
-        require(_value <= balances[msg.sender]);
-        // no need to require value <= totalSupply, since that would imply the
-        // sender's balance is greater than the totalSupply, which *should* be an assertion failure
+  /**
+   * @dev Burns a specific amount of tokens.
+   * @param _value The amount of token to be burned.
+   */
+  function burn(uint256 _value) public {
+    require(_value > 0);
+    require(_value <= balances[msg.sender]);
+    // no need to require value <= totalSupply, since that would imply the
+    // sender's balance is greater than the totalSupply, which *should* be an assertion failure
 
-        address burner = msg.sender;
-        balances[burner] = balances[burner].sub(_value);
-        totalSupply = totalSupply.sub(_value);
-        Burn(burner, _value);
-    }
+    address burner = msg.sender;
+    balances[burner] = balances[burner].sub(_value);
+    totalSupply = totalSupply.sub(_value);
+    Burn(burner, _value);
+  }
 }

--- a/contracts/token/PausableToken.sol
+++ b/contracts/token/PausableToken.sol
@@ -3,31 +3,67 @@ pragma solidity ^0.4.11;
 import './StandardToken.sol';
 import '../lifecycle/Pausable.sol';
 
+
 /**
  * @title Pausable token
  *
  * @dev StandardToken modified with pausable transfers.
  **/
-
 contract PausableToken is StandardToken, Pausable {
 
-  function transfer(address _to, uint256 _value) public whenNotPaused returns (bool) {
+  function transfer(
+    address _to,
+    uint256 _value
+  )
+    public
+    whenNotPaused
+    returns (bool)
+  {
     return super.transfer(_to, _value);
   }
 
-  function transferFrom(address _from, address _to, uint256 _value) public whenNotPaused returns (bool) {
+  function transferFrom(
+    address _from,
+    address _to,
+    uint256 _value
+  ) 
+    public
+    whenNotPaused
+    returns (bool)
+  {
     return super.transferFrom(_from, _to, _value);
   }
 
-  function approve(address _spender, uint256 _value) public whenNotPaused returns (bool) {
+  function approve(
+    address _spender,
+    uint256 _value
+  ) 
+    public
+    whenNotPaused
+    returns (bool)
+  {
     return super.approve(_spender, _value);
   }
 
-  function increaseApproval(address _spender, uint _addedValue) public whenNotPaused returns (bool success) {
+  function increaseApproval(
+    address _spender,
+    uint _addedValue
+  )
+    public
+    whenNotPaused
+    returns (bool success)
+  {
     return super.increaseApproval(_spender, _addedValue);
   }
 
-  function decreaseApproval(address _spender, uint _subtractedValue) public whenNotPaused returns (bool success) {
+  function decreaseApproval(
+    address _spender,
+    uint _subtractedValue
+  ) 
+    public 
+    whenNotPaused
+    returns (bool success)
+  {
     return super.decreaseApproval(_spender, _subtractedValue);
   }
 }

--- a/contracts/token/SafeERC20.sol
+++ b/contracts/token/SafeERC20.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.11;
 import './ERC20Basic.sol';
 import './ERC20.sol';
 
+
 /**
  * @title SafeERC20
  * @dev Wrappers around ERC20 operations that throw on failure.

--- a/contracts/token/TokenTimelock.sol
+++ b/contracts/token/TokenTimelock.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.4.11;
 import './ERC20Basic.sol';
 import "../token/SafeERC20.sol";
 
+
 /**
  * @title TokenTimelock
  * @dev TokenTimelock is a token holder contract that will allow a
@@ -21,7 +22,7 @@ contract TokenTimelock {
   // timestamp when token release is enabled
   uint64 public releaseTime;
 
-  function TokenTimelock(ERC20Basic _token, address _beneficiary, uint64 _releaseTime) {
+  function TokenTimelock(ERC20Basic _token, address _beneficiary, uint64 _releaseTime) public {
     require(_releaseTime > now);
     token = _token;
     beneficiary = _beneficiary;

--- a/contracts/token/TokenVesting.sol
+++ b/contracts/token/TokenVesting.sol
@@ -5,6 +5,7 @@ import './SafeERC20.sol';
 import '../ownership/Ownable.sol';
 import '../math/SafeMath.sol';
 
+
 /**
  * @title TokenVesting
  * @dev A token holder contract that can release its token balance gradually like a
@@ -39,7 +40,15 @@ contract TokenVesting is Ownable {
    * @param _duration duration in seconds of the period in which the tokens will vest
    * @param _revocable whether the vesting is revocable or not
    */
-  function TokenVesting(address _beneficiary, uint256 _start, uint256 _cliff, uint256 _duration, bool _revocable) {
+  function TokenVesting(
+    address _beneficiary,
+    uint256 _start,
+    uint256 _cliff,
+    uint256 _duration,
+    bool _revocable
+  )
+    public
+  {
     require(_beneficiary != address(0));
     require(_cliff <= _duration);
 


### PR DESCRIPTION
refs #75 and #555 
Fixes #656

Solium config:

- "custom-rules-filename" is deprecated.
- "no-with" rule is also deprecated.

- "double-quotes" rule is deprecated. It was replaced by ["quotes", "double"].

- Added "mixedcase" (is included in solium:all). As pointed out on #555, bugs with this rule where fixed. Is there another reason to not to use it?

- Added security plugin. Set severity for security rules appropriately.
https://github.com/duaraghav8/solium-plugin-security#list-of-rules

- These rules are included in ` solium:all`, so they where removed:
    imports-on-top
    variable-declarations
    array-declarations
    operator-whitespace
    lbrace
        camelcase
    uppercase
    no-empty-blocks
    no-unused-vars
    blank-lines
    indentation
    whitespace
    deprecated-suicide
    pragma-on-top

Other:
	Refactored contracts to comply with the new rules.
	Abstract base contracts constructors marked internal instead of public.

Issues:
"quotes" rule doesn't seem to be working.