### PR TITLE
Add npm init in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ truffle init
 
 To install the OpenZeppelin library, run:
 ```sh
+npm init
 npm install zeppelin-solidity
 
 # If you are using yarn, add dependency like this -


### PR DESCRIPTION
#475 had fixed this in the docs, but it was still missing from the README as seen in #567.