### PR TITLE
Change timestamps to uint64

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -18,8 +18,8 @@ contract Crowdsale {
   MintableToken public token;
 
   // start and end timestamps where investments are allowed (both inclusive)
-  uint256 public startTime;
-  uint256 public endTime;
+  uint64 public startTime;
+  uint64 public endTime;
 
   // address where funds are collected
   address public wallet;
@@ -40,7 +40,7 @@ contract Crowdsale {
   event TokenPurchase(address indexed purchaser, address indexed beneficiary, uint256 value, uint256 amount);
 
 
-  function Crowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, address _wallet) public {
+  function Crowdsale(uint64 _startTime, uint64 _endTime, uint256 _rate, address _wallet) public {
     require(_startTime >= now);
     require(_endTime >= _startTime);
     require(_rate > 0);

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -30,7 +30,7 @@ contract SampleCrowdsaleToken is MintableToken {
  */
 contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
 
-  function SampleCrowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, uint256 _goal, uint256 _cap, address _wallet) public
+  function SampleCrowdsale(uint64 _startTime, uint64 _endTime, uint256 _rate, uint256 _goal, uint256 _cap, address _wallet) public
     CappedCrowdsale(_cap)
     FinalizableCrowdsale()
     RefundableCrowdsale(_goal)

--- a/test/helpers/CappedCrowdsaleImpl.sol
+++ b/test/helpers/CappedCrowdsaleImpl.sol
@@ -7,8 +7,8 @@ import '../../contracts/crowdsale/CappedCrowdsale.sol';
 contract CappedCrowdsaleImpl is CappedCrowdsale {
 
   function CappedCrowdsaleImpl (
-    uint256 _startTime,
-    uint256 _endTime,
+    uint64 _startTime,
+    uint64 _endTime,
     uint256 _rate,
     address _wallet,
     uint256 _cap

--- a/test/helpers/FinalizableCrowdsaleImpl.sol
+++ b/test/helpers/FinalizableCrowdsaleImpl.sol
@@ -7,8 +7,8 @@ import '../../contracts/crowdsale/FinalizableCrowdsale.sol';
 contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
 
   function FinalizableCrowdsaleImpl (
-    uint256 _startTime,
-    uint256 _endTime,
+    uint64 _startTime,
+    uint64 _endTime,
     uint256 _rate,
     address _wallet
   ) public

--- a/test/helpers/RefundableCrowdsaleImpl.sol
+++ b/test/helpers/RefundableCrowdsaleImpl.sol
@@ -7,8 +7,8 @@ import '../../contracts/crowdsale/RefundableCrowdsale.sol';
 contract RefundableCrowdsaleImpl is RefundableCrowdsale {
 
   function RefundableCrowdsaleImpl (
-    uint256 _startTime,
-    uint256 _endTime,
+    uint64 _startTime,
+    uint64 _endTime,
     uint256 _rate,
     address _wallet,
     uint256 _goal


### PR DESCRIPTION
Using uint64 instead of uint256 to possibly save gas costs as per https://github.com/OpenZeppelin/zeppelin-solidity/issues/517