### PR TITLE
There's no need to throw when burning 0 tokens

### DIFF
--- a/contracts/token/BurnableToken.sol
+++ b/contracts/token/BurnableToken.sol
@@ -15,7 +15,6 @@ contract BurnableToken is StandardToken {
      * @param _value The amount of token to be burned.
      */
     function burn(uint256 _value) public {
-        require(_value > 0);
         require(_value <= balances[msg.sender]);
         // no need to require value <= totalSupply, since that would imply the
         // sender's balance is greater than the totalSupply, which *should* be an assertion failure


### PR DESCRIPTION
Throwing when trying to burn 0 tokens is an unnecessary special case.
If another contract wants to burn() a variable amount, it should not be forced to deal with this special case of burning 0.