### PR TITLE
Burnable Token should be inherited from Basic Token issue#596

### DIFF
--- a/contracts/token/BurnableToken.sol
+++ b/contracts/token/BurnableToken.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.4.18;
 
-import './StandardToken.sol';
+import './BasicToken.sol';
 
 /**
  * @title Burnable Token
  * @dev Token that can be irreversibly burned (destroyed).
  */
-contract BurnableToken is StandardToken {
+contract BurnableToken is BasicToken {
 
     event Burn(address indexed burner, uint256 value);
 


### PR DESCRIPTION
Change inheritance Burnable Token from Basic Token, issue https://github.com/OpenZeppelin/zeppelin-solidity/issues/596

Tests are passed