### PR TITLE
Consistent spellings of reentrant

### DIFF
--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.18;
 
 /**
- * @title Helps contracts guard agains rentrancy attacks.
+ * @title Helps contracts guard agains reentrancy attacks.
  * @author Remco Bloemen <remco@2π.com>
  * @notice If you mark a function `nonReentrant`, you should also
  * mark it `external`.

--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -11,7 +11,7 @@ contract ReentrancyGuard {
   /**
    * @dev We use a single lock for the whole contract.
    */
-  bool private rentrancy_lock = false;
+  bool private reentrancy_lock = false;
 
   /**
    * @dev Prevents a contract from calling itself, directly or indirectly.
@@ -22,10 +22,10 @@ contract ReentrancyGuard {
    * wrapper marked as `nonReentrant`.
    */
   modifier nonReentrant() {
-    require(!rentrancy_lock);
-    rentrancy_lock = true;
+    require(!reentrancy_lock);
+    reentrancy_lock = true;
     _;
-    rentrancy_lock = false;
+    reentrancy_lock = false;
   }
 
 }


### PR DESCRIPTION
Changed `rentrancy_lock` variable to `reentrancy_lock`