### PR TITLE
Function state mutability can be restricted to pure

### DIFF
--- a/contracts/ownership/HasNoTokens.sol
+++ b/contracts/ownership/HasNoTokens.sol
@@ -17,7 +17,7 @@ contract HasNoTokens is CanReclaimToken {
   * @param value_ uint256 the amount of the specified token
   * @param data_ Bytes The data passed from the caller.
   */
-  function tokenFallback(address from_, uint256 value_, bytes data_) external {
+  function tokenFallback(address from_, uint256 value_, bytes data_) external pure {
     from_;
     value_;
     data_;


### PR DESCRIPTION
Addresses the issue on `truffle compile`:
```
zeppelin-solidity/contracts/ownership/HasNoTokens.sol:20:3: Warning: Function state mutability can be restricted to pure
  function tokenFallback(address from_, uint256 value_, bytes data_) external {
```