### PR TITLE
Remove duplicated constructor call in FinalizableCrowdsaleImpl

### DIFF
--- a/contracts/mocks/FinalizableCrowdsaleImpl.sol
+++ b/contracts/mocks/FinalizableCrowdsaleImpl.sol
@@ -13,7 +13,6 @@ contract FinalizableCrowdsaleImpl is FinalizableCrowdsale {
     address _wallet
   ) public
     Crowdsale(_startTime, _endTime, _rate, _wallet)
-    FinalizableCrowdsale()
   {
   }
 


### PR DESCRIPTION
This is going to be enforced by the compiler soon.