### PR TITLE
Add ECRecoveryMock contract

### DIFF
--- a/contracts/mocks/ECRecoveryMock.sol
+++ b/contracts/mocks/ECRecoveryMock.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.18;
+
+
+import '../ECRecovery.sol';
+
+
+contract ECRecoveryMock {
+  using ECRecovery for bytes32;
+
+  address public addrRecovered;
+
+  function recover(bytes32 hash, bytes sig) public returns (address) {
+    addrRecovered = hash.recover(sig);
+  }
+
+}

--- a/test/ECRecovery.test.js
+++ b/test/ECRecovery.test.js
@@ -5,6 +5,7 @@ var hashMessage = require('./helpers/hashMessage.js');
 
 contract('ECRecovery', function (accounts) {
   let ecrecovery;
+  const TEST_MESSAGE = 'OpenZeppelin'
 
   before(async function () {
     const ecRecoveryLib = await ECRecoveryLib.new();
@@ -15,7 +16,7 @@ contract('ECRecovery', function (accounts) {
   it('recover v0', async function () {
     // Signature generated outside testrpc with method web3.eth.sign(signer, message)
     let signer = '0x2cc1166f6212628a0deef2b33befb2187d35b86c';
-    let message = '0x7dbaf558b0a1a5dc7a67202117ab143c1d8605a983e4a743bc06fcc03162dc0d'; // web3.sha3('OpenZeppelin')
+    let message = web3.sha3(TEST_MESSAGE);
     // eslint-disable-next-line max-len
     let signature = '0x5d99b6f7f6d1f73d1a26497f2b1c89b24c0993913f86e9a2d02cd69887d9c94f3c880358579d811b21dd1b7fd9bb01c1d81d10e69f0384e675c32b39643be89200';
     await ecrecovery.recover(message, signature);
@@ -25,7 +26,7 @@ contract('ECRecovery', function (accounts) {
   it('recover v1', async function () {
     // Signature generated outside testrpc with method web3.eth.sign(signer, message)
     let signer = '0x1e318623ab09fe6de3c9b8672098464aeda9100e';
-    let message = '0x7dbaf558b0a1a5dc7a67202117ab143c1d8605a983e4a743bc06fcc03162dc0d'; // web3.sha3('OpenZeppelin')
+    let message = web3.sha3(TEST_MESSAGE);
     // eslint-disable-next-line max-len
     let signature = '0x331fe75a821c982f9127538858900d87d3ec1f9f737338ad67cad133fa48feff48e6fa0c18abc62e42820f05943e47af3e9fbe306ce74d64094bdf1691ee53e001';
     await ecrecovery.recover(message, signature);
@@ -34,28 +35,28 @@ contract('ECRecovery', function (accounts) {
 
   it('recover using web3.eth.sign()', async function () {
     // Create the signature using account[0]
-    const signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
+    const signature = web3.eth.sign(accounts[0], web3.sha3(TEST_MESSAGE));
 
-    // Recover the signer address form the generated message and signature.
-    await ecrecovery.recover(hashMessage('OpenZeppelin'), signature);
+    // Recover the signer address from the generated message and signature.
+    await ecrecovery.recover(hashMessage(TEST_MESSAGE), signature);
     assert.equal(accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover using web3.eth.sign() should return wrong signer', async function () {
     // Create the signature using account[0]
-    const signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
+    const signature = web3.eth.sign(accounts[0], web3.sha3(TEST_MESSAGE));
 
-    // Recover the signer address form the generated message and wrong signature.
+    // Recover the signer address from the generated message and wrong signature.
     await ecrecovery.recover(hashMessage('Test'), signature);
     assert.notEqual(accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover should fail when a wrong hash is sent', async function () {
     // Create the signature using account[0]
-    let signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
+    let signature = web3.eth.sign(accounts[0], web3.sha3(TEST_MESSAGE));
 
-    // Recover the signer address form the generated message and wrong signature.
-    await ecrecovery.recover(hashMessage('OpenZeppelin').substring(2), signature);
+    // Recover the signer address from the generated message and wrong signature.
+    await ecrecovery.recover(hashMessage(TEST_MESSAGE).substring(2), signature);
     assert.equal('0x0000000000000000000000000000000000000000', await ecrecovery.addrRecovered());
   });
 });

--- a/test/ECRecovery.test.js
+++ b/test/ECRecovery.test.js
@@ -34,25 +34,25 @@ contract('ECRecovery', function (accounts) {
 
   it('recover using web3.eth.sign()', async function () {
     // Create the signature using account[0]
-    const signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
+    const signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and signature.
     await ecrecovery.recover(hashMessage('OpenZeppelin'), signature);
-    assert.equal(web3.eth.accounts[0], await ecrecovery.addrRecovered());
+    assert.equal(accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover using web3.eth.sign() should return wrong signer', async function () {
     // Create the signature using account[0]
-    const signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
+    const signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and wrong signature.
     await ecrecovery.recover(hashMessage('Test'), signature);
-    assert.notEqual(web3.eth.accounts[0], await ecrecovery.addrRecovered());
+    assert.notEqual(accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover should fail when a wrong hash is sent', async function () {
     // Create the signature using account[0]
-    let signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
+    let signature = web3.eth.sign(accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and wrong signature.
     await ecrecovery.recover(hashMessage('OpenZeppelin').substring(2), signature);

--- a/test/ECRecovery.test.js
+++ b/test/ECRecovery.test.js
@@ -5,7 +5,7 @@ var hashMessage = require('./helpers/hashMessage.js');
 
 contract('ECRecovery', function (accounts) {
   let ecrecovery;
-  const TEST_MESSAGE = 'OpenZeppelin'
+  const TEST_MESSAGE = 'OpenZeppelin';
 
   before(async function () {
     const ecRecoveryLib = await ECRecoveryLib.new();

--- a/test/ECRecovery.test.js
+++ b/test/ECRecovery.test.js
@@ -1,11 +1,15 @@
-var ECRecovery = artifacts.require('../contracts/ECRecovery.sol');
+var ECRecoveryMock = artifacts.require('../contracts/mocks/ECRecoveryMock.sol');
+var ECRecoveryLib = artifacts.require('../contracts/ECRecovery.sol');
+
 var hashMessage = require('./helpers/hashMessage.js');
 
 contract('ECRecovery', function (accounts) {
   let ecrecovery;
 
   before(async function () {
-    ecrecovery = await ECRecovery.new();
+    const ecRecoveryLib = await ECRecoveryLib.new();
+    ECRecoveryMock.link('ECRecovery', ecRecoveryLib.address);
+    ecrecovery = await ECRecoveryMock.new();
   });
 
   it('recover v0', async function () {
@@ -14,7 +18,8 @@ contract('ECRecovery', function (accounts) {
     let message = '0x7dbaf558b0a1a5dc7a67202117ab143c1d8605a983e4a743bc06fcc03162dc0d'; // web3.sha3('OpenZeppelin')
     // eslint-disable-next-line max-len
     let signature = '0x5d99b6f7f6d1f73d1a26497f2b1c89b24c0993913f86e9a2d02cd69887d9c94f3c880358579d811b21dd1b7fd9bb01c1d81d10e69f0384e675c32b39643be89200';
-    assert.equal(signer, await ecrecovery.recover(message, signature));
+    await ecrecovery.recover(message, signature);
+    assert.equal(signer, await ecrecovery.addrRecovered());
   });
 
   it('recover v1', async function () {
@@ -23,7 +28,8 @@ contract('ECRecovery', function (accounts) {
     let message = '0x7dbaf558b0a1a5dc7a67202117ab143c1d8605a983e4a743bc06fcc03162dc0d'; // web3.sha3('OpenZeppelin')
     // eslint-disable-next-line max-len
     let signature = '0x331fe75a821c982f9127538858900d87d3ec1f9f737338ad67cad133fa48feff48e6fa0c18abc62e42820f05943e47af3e9fbe306ce74d64094bdf1691ee53e001';
-    assert.equal(signer, await ecrecovery.recover(message, signature));
+    await ecrecovery.recover(message, signature);
+    assert.equal(signer, await ecrecovery.addrRecovered());
   });
 
   it('recover using web3.eth.sign()', async function () {
@@ -31,7 +37,8 @@ contract('ECRecovery', function (accounts) {
     const signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and signature.
-    assert.equal(web3.eth.accounts[0], await ecrecovery.recover(hashMessage('OpenZeppelin'), signature));
+    await ecrecovery.recover(hashMessage('OpenZeppelin'), signature);
+    assert.equal(web3.eth.accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover using web3.eth.sign() should return wrong signer', async function () {
@@ -39,7 +46,8 @@ contract('ECRecovery', function (accounts) {
     const signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and wrong signature.
-    assert.notEqual(web3.eth.accounts[0], await ecrecovery.recover(hashMessage('Test'), signature));
+    await ecrecovery.recover(hashMessage('Test'), signature);
+    assert.notEqual(web3.eth.accounts[0], await ecrecovery.addrRecovered());
   });
 
   it('recover should fail when a wrong hash is sent', async function () {
@@ -47,8 +55,7 @@ contract('ECRecovery', function (accounts) {
     let signature = web3.eth.sign(web3.eth.accounts[0], web3.sha3('OpenZeppelin'));
 
     // Recover the signer address form the generated message and wrong signature.
-    assert.equal('0x0000000000000000000000000000000000000000',
-      await ecrecovery.recover(hashMessage('OpenZeppelin').substring(2), signature)
-    );
+    await ecrecovery.recover(hashMessage('OpenZeppelin').substring(2), signature);
+    assert.equal('0x0000000000000000000000000000000000000000', await ecrecovery.addrRecovered());
   });
 });


### PR DESCRIPTION
Add a mock contract to tests the ECRecovery lib as an extension of `bytes32` variables using:
```
using ECRecovery for bytes32;
```