### PR TITLE
Update function modifier in docs

### DIFF
--- a/docs/source/basictoken.rst
+++ b/docs/source/basictoken.rst
@@ -3,7 +3,7 @@ BasicToken
 
 Simpler version of StandardToken, with no allowances
 
-balanceOf(address _owner) constant returns (uint balance)
+balanceOf(address _owner) view returns (uint balance)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Returns the token balance of the passed address.
 

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -3,22 +3,22 @@ Math
 
 Provides assorted low-level math operations.
 
-max64(uint64 a, uint64 b) internal constant returns (uint64)
+max64(uint64 a, uint64 b) internal pure returns (uint64)
 """""""""""""""""""""""""""""""""""""""""""""""""
 
 Returns the largest of two uint64 numbers.
 
-min64(uint64 a, uint64 b) internal constant returns (uint64)
+min64(uint64 a, uint64 b) internal pure returns (uint64)
 """""""""""""""""""""""""""""""""""""""""""""""""
 
 Returns the smallest of two uint64 numbers.
 
-max64(uint256 a, uint256 b) internal constant returns (uint256)
+max64(uint256 a, uint256 b) internal pure returns (uint256)
 """""""""""""""""""""""""""""""""""""""""""""""""
 
 Returns the largest of two uint256 numbers.
 
-min64(uint256 a, uint256 b) internal constant returns (uint256)
+min64(uint256 a, uint256 b) internal pure returns (uint256)
 """""""""""""""""""""""""""""""""""""""""""""""""
 
 Returns the smallest of two uint256 numbers.

--- a/docs/source/standardtoken.rst
+++ b/docs/source/standardtoken.rst
@@ -9,11 +9,11 @@ approve(address _spender, uint _value) returns (bool success)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Sets the amount of the sender's token balance that the passed address is approved to use.
 
-allowance(address _owner, address _spender) constant returns (uint remaining)
+allowance(address _owner, address _spender) view returns (uint remaining)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Returns the approved amount of the owner's balance that the spender can use.
 
-balanceOf(address _owner) constant returns (uint balance)
+balanceOf(address _owner) view returns (uint balance)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Returns the token balance of the passed address.
 


### PR DESCRIPTION
These three docs are not updated on function modifier(using `constant`) while its contract already did (using `view` or `pure`). 