### PR TITLE
Unnecessary use of require when using SafeMath

### DIFF
--- a/contracts/token/ERC20/StandardToken.sol
+++ b/contracts/token/ERC20/StandardToken.sol
@@ -30,7 +30,7 @@ contract StandardToken is ERC20, BasicToken {
 
     balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);
-    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
+    allowed[_from][msg.sender] = _allowance.sub(_value);
     Transfer(_from, _to, _value);
     return true;
   }

--- a/contracts/token/ERC20/StandardToken.sol
+++ b/contracts/token/ERC20/StandardToken.sol
@@ -24,8 +24,9 @@ contract StandardToken is ERC20, BasicToken {
    */
   function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
     require(_to != address(0));
-    require(_value <= balances[_from]);
-    require(_value <= allowed[_from][msg.sender]);
+    uint256 _allowance = allowed[_from][msg.sender];
+    //require(_value <= balances[_from]); *Use of require is no longer necessary, due to SafeMath.sub throwing an error.
+    //require(_value <= allowed[_from][msg.sender]); *Use of require is no longer necessary, due to SafeMath.sub throwing an error.
 
     balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);


### PR DESCRIPTION
Check is not needed because SafeMath.sub will already throw an error if this condition is not met.

