### PR TITLE
Optimize crowdsale contract

### DIFF
--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -24,14 +24,17 @@ contract Crowdsale {
   uint256 public startTime;
   uint256 public endTime;
 
-  // address where funds are collected
-  address public wallet;
-
   // how many token units a buyer gets per wei
   uint256 public rate;
 
   // amount of raised money in wei
   uint256 public weiRaised;
+
+  // address where funds are collected
+  address public wallet;
+
+
+
 
   /**
    * event for token purchase logging


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description
I noticed that the 256 units should be grouped together optimize the contract at compile time. This is a very simple fix that makes sure the 256 variables are grouped together. It doesn't touch anything else other than that. 

<!-- 2. Describe the changes introduced in this pull request -->

I just moved a line of code in the crowdsale contract so it's grouped together. 
<!--    Include any context necessary for understanding the PR's purpose. -->
This should decrease the cost to deploy the contract.

