### PR TITLE
Decouple RefundVault from RefundableCrowdsale

### DIFF
--- a/contracts/crowdsale/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/RefundableCrowdsale.sol
@@ -21,9 +21,10 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
   // refund vault used to hold funds while crowdsale is running
   RefundVault public vault;
 
-  function RefundableCrowdsale(uint256 _goal) public {
+  function RefundableCrowdsale(uint256 _goal, RefundVault _vault) public {
     require(_goal > 0);
-    vault = new RefundVault(wallet);
+    require(_vault != address(0));
+    vault = _vault;
     goal = _goal;
   }
 

--- a/contracts/examples/SampleCrowdsale.sol
+++ b/contracts/examples/SampleCrowdsale.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 import "../crowdsale/CappedCrowdsale.sol";
 import "../crowdsale/RefundableCrowdsale.sol";
+import "../crowdsale/RefundVault.sol";
 import "../token/ERC20/MintableToken.sol";
 
 
@@ -32,10 +33,10 @@ contract SampleCrowdsaleToken is MintableToken {
  */
 contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
 
-  function SampleCrowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, uint256 _goal, uint256 _cap, address _wallet, MintableToken _token) public
+  function SampleCrowdsale(uint256 _startTime, uint256 _endTime, uint256 _rate, uint256 _goal, uint256 _cap, address _wallet, MintableToken _token, RefundVault _vault) public
     CappedCrowdsale(_cap)
     FinalizableCrowdsale()
-    RefundableCrowdsale(_goal)
+    RefundableCrowdsale(_goal, _vault)
     Crowdsale(_startTime, _endTime, _rate, _wallet, _token)
   {
     //As goal needs to be met for a successful crowdsale

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -12,8 +12,8 @@ contract RefundableCrowdsaleImpl is RefundableCrowdsale {
     uint256 _rate,
     address _wallet,
     uint256 _goal,
-    RefundVault _vault,
-    MintableToken _token
+    MintableToken _token,
+    RefundVault _vault
   ) public
     Crowdsale(_startTime, _endTime, _rate, _wallet, _token)
     RefundableCrowdsale(_goal, _vault)

--- a/contracts/mocks/RefundableCrowdsaleImpl.sol
+++ b/contracts/mocks/RefundableCrowdsaleImpl.sol
@@ -12,10 +12,11 @@ contract RefundableCrowdsaleImpl is RefundableCrowdsale {
     uint256 _rate,
     address _wallet,
     uint256 _goal,
+    RefundVault _vault,
     MintableToken _token
   ) public
     Crowdsale(_startTime, _endTime, _rate, _wallet, _token)
-    RefundableCrowdsale(_goal)
+    RefundableCrowdsale(_goal, _vault)
   {
   }
 

--- a/test/crowdsale/CappedCrowdsale.test.js
+++ b/test/crowdsale/CappedCrowdsale.test.js
@@ -36,7 +36,13 @@ contract('CappedCrowdsale', function ([_, wallet]) {
 
   describe('creating a valid crowdsale', function () {
     it('should fail with zero cap', async function () {
-      await CappedCrowdsale.new(this.startTime, this.endTime, rate, wallet, 0).should.be.rejectedWith(EVMRevert);
+      await CappedCrowdsale.new(
+        this.startTime,
+        this.endTime,
+        rate, wallet,
+        0,
+        this.token.address
+      ).should.be.rejectedWith(EVMRevert);
     });
   });
 

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -13,6 +13,7 @@ require('chai')
 
 const RefundableCrowdsale = artifacts.require('RefundableCrowdsaleImpl');
 const MintableToken = artifacts.require('MintableToken');
+const RefundVault = artifacts.require('RefundVault');
 
 contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
   const rate = new BigNumber(1000);
@@ -30,15 +31,33 @@ contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
     this.afterEndTime = this.endTime + duration.seconds(1);
 
     this.token = await MintableToken.new();
+    this.vault = await RefundVault.new(wallet);
+
     this.crowdsale = await RefundableCrowdsale.new(
-      this.startTime, this.endTime, rate, wallet, goal, this.token.address, { from: owner }
+      this.startTime,
+      this.endTime,
+      rate,
+      wallet,
+      goal,
+      this.vault.address,
+      this.token.address
     );
+
     await this.token.transferOwnership(this.crowdsale.address);
+    await this.vault.transferOwnership(this.crowdsale.address);
   });
 
   describe('creating a valid crowdsale', function () {
     it('should fail with zero goal', async function () {
-      await RefundableCrowdsale.new(this.startTime, this.endTime, rate, wallet, 0, { from: owner })
+      await RefundableCrowdsale.new(
+        this.startTime,
+        this.endTime,
+        rate,
+        wallet,
+        0,
+        this.vault.address,
+        this.token.address
+      )
         .should.be.rejectedWith(EVMRevert);
     });
   });

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -39,8 +39,8 @@ contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
       rate,
       wallet,
       goal,
-      this.vault.address,
       this.token.address,
+      this.vault.address,
       { from: owner }
     );
 
@@ -56,8 +56,8 @@ contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
         rate,
         wallet,
         0,
-        this.vault.address,
         this.token.address,
+        this.vault.address,
         { from: owner }
       )
         .should.be.rejectedWith(EVMRevert);

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -40,7 +40,8 @@ contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
       wallet,
       goal,
       this.vault.address,
-      this.token.address
+      this.token.address,
+      { from: owner }
     );
 
     await this.token.transferOwnership(this.crowdsale.address);
@@ -56,7 +57,8 @@ contract('RefundableCrowdsale', function ([_, owner, wallet, investor]) {
         wallet,
         0,
         this.vault.address,
-        this.token.address
+        this.token.address,
+        { from: owner }
       )
         .should.be.rejectedWith(EVMRevert);
     });

--- a/test/examples/SampleCrowdsale.test.js
+++ b/test/examples/SampleCrowdsale.test.js
@@ -13,6 +13,7 @@ require('chai')
 
 const SampleCrowdsale = artifacts.require('SampleCrowdsale');
 const SampleCrowdsaleToken = artifacts.require('SampleCrowdsaleToken');
+const RefundVault = artifacts.require('RefundVault');
 
 contract('SampleCrowdsale', function ([owner, wallet, investor]) {
   const RATE = new BigNumber(10);
@@ -30,15 +31,20 @@ contract('SampleCrowdsale', function ([owner, wallet, investor]) {
     this.afterEndTime = this.endTime + duration.seconds(1);
 
     this.token = await SampleCrowdsaleToken.new();
+    this.vault = await RefundVault.new(wallet, { from: owner });
+
     this.crowdsale = await SampleCrowdsale.new(
-      this.startTime, this.endTime, RATE, GOAL, CAP, wallet, this.token.address
+      this.startTime, this.endTime, RATE, GOAL, CAP, wallet, this.token.address, this.vault.address
     );
+    
+    await this.vault.transferOwnership(this.crowdsale.address);
     await this.token.transferOwnership(this.crowdsale.address);
   });
 
   it('should create crowdsale with correct parameters', async function () {
     this.crowdsale.should.exist;
     this.token.should.exist;
+    this.vault.should.exist;
 
     const startTime = await this.crowdsale.startTime();
     const endTime = await this.crowdsale.endTime();


### PR DESCRIPTION
# 🚀 Description

After a quick chat with @spalladino and @fiiiu  we all agreed that it would be a good idea to decouple RefundVault from RefundableCrowdsale.

Right now, after the Crowdsale goal is reached, **ALL** the funds are transferred to the wallet on finalization and there's no way of adding  / overriding any logic.

After this, you should be able to create a contract that extends from RefundVault which will give you the ability to override its methods ( mainly close() and refund() )

- [X] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [X] ✅ I've added tests where applicable to test my new functionality.
- [X] 📖 I've made sure that my contracts are well-documented.
- [X] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).  