### PR TITLE
make BurnableToken consistent w/ MintableToken

### DIFF
--- a/contracts/token/ERC20/BurnableToken.sol
+++ b/contracts/token/ERC20/BurnableToken.sol
@@ -1,29 +1,32 @@
 pragma solidity ^0.4.18;
 
 import "./BasicToken.sol";
+import "../../ownership/Ownable.sol";
 
 
 /**
  * @title Burnable Token
  * @dev Token that can be irreversibly burned (destroyed).
  */
-contract BurnableToken is BasicToken {
+contract BurnableToken is BasicToken, Ownable {
 
-  event Burn(address indexed burner, uint256 value);
+  event Burn(address indexed from, uint256 amount);
 
   /**
-   * @dev Burns a specific amount of tokens.
-   * @param _value The amount of token to be burned.
+   * @dev Function to burn tokens
+   * @param _from The address that tokens will be burned from.
+   * @param _amount The amount of tokens to burn.
+   * @return A boolean that indicates if the operation was successful.
    */
-  function burn(uint256 _value) public {
-    require(_value <= balances[msg.sender]);
+  function burn(address _from, uint256 _amount) onlyOwner public returns (bool) {
+    require(_amount <= balances[_from]);
     // no need to require value <= totalSupply, since that would imply the
     // sender's balance is greater than the totalSupply, which *should* be an assertion failure
 
-    address burner = msg.sender;
-    balances[burner] = balances[burner].sub(_value);
-    totalSupply_ = totalSupply_.sub(_value);
-    Burn(burner, _value);
-    Transfer(burner, address(0), _value);
+    balances[_from] = balances[_from].sub(_amount);
+    totalSupply_ = totalSupply_.sub(_amount);
+    Burn(_from, _amount);
+    Transfer(_from, address(0), _amount);
+    return true;
   }
 }

--- a/test/token/BurnableToken.test.js
+++ b/test/token/BurnableToken.test.js
@@ -1,7 +1,7 @@
 import assertRevert from '../helpers/assertRevert';
 const BurnableTokenMock = artifacts.require('BurnableTokenMock');
 
-contract('BurnableToken', function ([owner]) {
+contract('BurnableToken', function ([owner, anotherAccount]) {
   beforeEach(async function () {
     this.token = await BurnableTokenMock.new(owner, 1000);
   });
@@ -9,23 +9,36 @@ contract('BurnableToken', function ([owner]) {
   describe('burn', function () {
     const from = owner;
 
-    describe('when the given amount is not greater than balance of the sender', function () {
+    describe('when the given amount is not greater than balance of the burn address', function () {
       const amount = 100;
 
-      it('burns the requested amount', async function () {
-        await this.token.burn(amount, { from });
+      it('burns the requested amount from the owner', async function () {
+        await this.token.burn(owner, amount, { from });
 
         const balance = await this.token.balanceOf(from);
         assert.equal(balance, 900);
+
+        const totalSupply = await this.token.totalSupply();
+        assert.equal(totalSupply, 900);
+      });
+
+      it('burns the requested amount from another account', async function () {
+        await this.token.transfer(anotherAccount, amount, { from: owner });
+        await this.token.burn(anotherAccount, 10, { from });
+        const balance = await this.token.balanceOf(anotherAccount);
+        assert.equal(balance, 90);
+
+        const totalSupply = await this.token.totalSupply();
+        assert.equal(totalSupply, 990);
       });
 
       it('emits a burn event', async function () {
-        const { logs } = await this.token.burn(amount, { from });
+        const { logs } = await this.token.burn(owner, amount, { from });
         const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
         assert.equal(logs.length, 2);
         assert.equal(logs[0].event, 'Burn');
-        assert.equal(logs[0].args.burner, owner);
-        assert.equal(logs[0].args.value, amount);
+        assert.equal(logs[0].args.from, owner);
+        assert.equal(logs[0].args.amount, amount);
 
         assert.equal(logs[1].event, 'Transfer');
         assert.equal(logs[1].args.from, owner);
@@ -34,11 +47,34 @@ contract('BurnableToken', function ([owner]) {
       });
     });
 
-    describe('when the given amount is greater than the balance of the sender', function () {
+    describe('when the given amount is greater than the balance of the burn address', function () {
       const amount = 1001;
 
       it('reverts', async function () {
-        await assertRevert(this.token.burn(amount, { from }));
+        await assertRevert(this.token.burn(owner, amount, { from }));
+
+        const totalSupply = await this.token.totalSupply();
+        assert.equal(totalSupply, 1000);
+      });
+
+      it('reverts', async function () {
+        await assertRevert(this.token.burn(anotherAccount, amount, { from }));
+      });
+    });
+
+    describe('when the caller is not the owner', function () {
+      const amount = 100;
+
+      it('reverts', async function () {
+        await assertRevert(this.token.burn(owner, amount, { from: anotherAccount }));
+      });
+
+      it('reverts', async function () {
+        await this.token.transfer(anotherAccount, amount, { from: owner });
+        await assertRevert(this.token.burn(anotherAccount, 10, { from: anotherAccount }));
+
+        const totalSupply = await this.token.totalSupply();
+        assert.equal(totalSupply, 1000);
       });
     });
   });


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #785 

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

Changes the interface of `BurnableToken` `burn` => ` function burn(address _from, uint256 _amount) onlyOwner public returns (bool)` to be consistent with `MintableToken` `mint`. The improvements are as follows:

1. Only the owner of the contract can `burn` tokens (seems to be much more useful/standard than anybody being able to `burn`.
2. The owner can choose which account to `burn` from.
3. Makes unit-tests more thorough in general for `BurnableToken` and adds unit-tests for functionality added in this PR.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).