### PR TITLE
Fix version error for truffle-flattener.

### DIFF
--- a/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
+++ b/contracts/crowdsale/validation/IndividuallyCappedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^ 0.4.18;
+pragma solidity ^0.4.18;
 
 import "../../math/SafeMath.sol";
 import "../Crowdsale.sol";
@@ -36,7 +36,7 @@ contract IndividuallyCappedCrowdsale is Crowdsale, Ownable {
   }
 
   /**
-   * @dev Returns the cap of a specific user. 
+   * @dev Returns the cap of a specific user.
    * @param _beneficiary Address whose cap is to be checked
    * @return Current cap for individual user
    */

--- a/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
+++ b/contracts/crowdsale/validation/WhitelistedCrowdsale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^ 0.4.18;
+pragma solidity ^0.4.18;
 
 import "../Crowdsale.sol";
 import "../../ownership/Ownable.sol";
@@ -27,9 +27,9 @@ contract WhitelistedCrowdsale is Crowdsale, Ownable {
   function addToWhitelist(address _beneficiary) external onlyOwner {
     whitelist[_beneficiary] = true;
   }
-  
+
   /**
-   * @dev Adds list of addresses to whitelist. Not overloaded due to limitations with truffle testing. 
+   * @dev Adds list of addresses to whitelist. Not overloaded due to limitations with truffle testing.
    * @param _beneficiaries Addresses to be added to the whitelist
    */
   function addManyToWhitelist(address[] _beneficiaries) external onlyOwner {
@@ -39,7 +39,7 @@ contract WhitelistedCrowdsale is Crowdsale, Ownable {
   }
 
   /**
-   * @dev Removes single address from whitelist. 
+   * @dev Removes single address from whitelist.
    * @param _beneficiary Address to be removed to the whitelist
    */
   function removeFromWhitelist(address _beneficiary) external onlyOwner {


### PR DESCRIPTION
Fixing error when try to create a single file contracts with truffle-flattener.

# 🚀 Description
The space on solidity version number is not cause error when try to create a single file contracts with truffle-flattener.
<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [X] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [X] ✅ I've added tests where applicable to test my new functionality.
- [X] 📖 I've made sure that my contracts are well-documented.
- [X] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).