### PR TITLE
add case when to is equal to 0 an have a previos approve

### DIFF
--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -100,7 +100,9 @@ contract ERC721Token is ERC721 {
     if (approvedFor(_tokenId) != 0 || _to != 0) {
       tokenApprovals[_tokenId] = _to;
       Approval(owner, _to, _tokenId);
-    }
+    } else if (_to == 0 && approvedFor(_tokenId) != 0) {
+      clearApproval(owner, _tokenId);
+      }
   }
 
   /**


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->
In https://github.com/ethereum/eips/issues/721 the official draft of ERC721 token, in the approve function, when the _to address is equal to 0 and have a previous state, the function have to clear the state and trigger the approve event. 
<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).