### PR TITLE
 Small gas improvement in SafeMath.sol

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -24,9 +24,9 @@ library SafeMath {
   */
   function div(uint256 a, uint256 b) internal pure returns (uint256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
-    uint256 c = a / b;
+    // uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-    return c;
+    return a / b;
   }
 
   /**


### PR DESCRIPTION
# 🚀 Description

Although this is nothing major, by not allocating memory to an extra variable, some gas can be saved in this (overall used) library.

I kept the original code in comments for devs to read what the original safety checks were and why they were removed.

<!-- 2. Describe the changes introduced in this pull request -->

Originally the `div` functions had 2 safety checks.

```Solidity
/**
 * @dev Integer division of two numbers, truncating the quotient.
 */
function div(uint256 a, uint256 b) internal pure returns (uint256) {
    assert(b > 0);
    uint256 c = a / b;
    assert(a == b * c + a % b);
    return c;
}
```

It was improved by removing the checks because they were not needed.

```Solidity
/**
 * @dev Integer division of two numbers, truncating the quotient.
 */
function div(uint256 a, uint256 b) internal pure returns (uint256) {
    // assert(b > 0); // Solidity automatically throws when dividing by 0
    uint256 c = a / b;
    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
    return c;
}
```

This was good so far but the `c` variable is not needed anymore.

```Solidity
/**
 * @dev Integer division of two numbers, truncating the quotient.
 */
function div(uint256 a, uint256 b) internal pure returns (uint256) {
    // assert(b > 0); // Solidity automatically throws when dividing by 0
    // uint256 c = a / b;
    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
    return a / b;
}
```

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).