### PR TITLE
Change ECRecovery recover method's visibility to internal

### DIFF
--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -14,7 +14,7 @@ library ECRecovery {
    * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
    * @param sig bytes signature, the signature is generated using web3.eth.sign()
    */
-  function recover(bytes32 hash, bytes sig) public pure returns (address) {
+  function recover(bytes32 hash, bytes sig) internal pure returns (address) {
     bytes32 r;
     bytes32 s;
     uint8 v;

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -8,8 +8,6 @@ contract('ECRecovery', function (accounts) {
   const TEST_MESSAGE = 'OpenZeppelin';
 
   before(async function () {
-    const ecRecoveryLib = await ECRecoveryLib.new();
-    ECRecoveryMock.link('ECRecovery', ecRecoveryLib.address);
     ecrecovery = await ECRecoveryMock.new();
   });
 

--- a/test/library/ECRecovery.test.js
+++ b/test/library/ECRecovery.test.js
@@ -1,5 +1,4 @@
 var ECRecoveryMock = artifacts.require('ECRecoveryMock');
-var ECRecoveryLib = artifacts.require('ECRecovery');
 
 var hashMessage = require('../helpers/hashMessage.js');
 


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
This changes ECRecovery's recover method from `public` to `internal`. ECRecovery is a utility function. Defining it as `public` would mean anyone who uses it would have to deploy it separately, causing extra gas, which seems overkill. Internalizing it saves all that.

It doesn't seem to break any tests.

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).