### PR TITLE
_burn() is internal and shouldn't require msg.sender to be owner

### DIFF
--- a/contracts/mocks/ERC721TokenMock.sol
+++ b/contracts/mocks/ERC721TokenMock.sol
@@ -13,7 +13,7 @@ contract ERC721TokenMock is ERC721Token {
     super._mint(_to, _tokenId);
   }
 
-  function burn(uint256 _tokenId) public {
+  function burn(uint256 _tokenId) onlyOwnerOf(_tokenId) public {
     super._burn(_tokenId);
   }
 }

--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -127,12 +127,13 @@ contract ERC721Token is ERC721 {
   * @dev Burns a specific token
   * @param _tokenId uint256 ID of the token being burned by the msg.sender
   */
-  function _burn(uint256 _tokenId) onlyOwnerOf(_tokenId) internal {
+  function _burn(uint256 _tokenId) internal {
+    address owner = ownerOf(_tokenId);
     if (approvedFor(_tokenId) != 0) {
-      clearApproval(msg.sender, _tokenId);
+      clearApproval(owner, _tokenId);
     }
-    removeToken(msg.sender, _tokenId);
-    Transfer(msg.sender, 0x0, _tokenId);
+    removeToken(owner, _tokenId);
+    Transfer(owner, 0x0, _tokenId);
   }
 
   /**


### PR DESCRIPTION
# 🚀 Description

Doesn't require `msg.sender` for the `internal` function `_burn()` in ERC721Token.sol to be the owner of the token. ERC721 tokens that inherit from your contract may want to use `_burn()` without this restriction.