### PR TITLE
Gender of signer is irrelevant and distracting

### DIFF
--- a/contracts/ECRecovery.sol
+++ b/contracts/ECRecovery.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.4.18;
 library ECRecovery {
 
   /**
-   * @dev Recover signer address from a message by using his signature
+   * @dev Recover signer address from a message by using their signature
    * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
    * @param sig bytes signature, the signature is generated using web3.eth.sign()
    */


### PR DESCRIPTION
# 🚀 Description

A comment was made more generally applicable 
The gender of a signer is irrelevant and distracting so "his" was replaced by "their".

<!-- 3. Before submitting, please review the following checklist: -->

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [_] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).