### PR TITLE
Removing more asserts in favor of require

### DIFF
--- a/contracts/ownership/HasNoEther.sol
+++ b/contracts/ownership/HasNoEther.sol
@@ -36,6 +36,6 @@ contract HasNoEther is Ownable {
    * @dev Transfer all Ether held by the contract to the owner.
    */
   function reclaimEther() external onlyOwner {
-    assert(owner.send(this.balance));
+    owner.transfer(this.balance);
   }
 }

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -12,14 +12,14 @@ import "./ERC20.sol";
  */
 library SafeERC20 {
   function safeTransfer(ERC20Basic token, address to, uint256 value) internal {
-    assert(token.transfer(to, value));
+    require(token.transfer(to, value));
   }
 
   function safeTransferFrom(ERC20 token, address from, address to, uint256 value) internal {
-    assert(token.transferFrom(from, to, value));
+    require(token.transferFrom(from, to, value));
   }
 
   function safeApprove(ERC20 token, address spender, uint256 value) internal {
-    assert(token.approve(spender, value));
+    require(token.approve(spender, value));
   }
 }

--- a/test/token/ERC20/SafeERC20.test.js
+++ b/test/token/ERC20/SafeERC20.test.js
@@ -1,4 +1,4 @@
-import EVMThrow from '../../helpers/EVMThrow';
+import EVMRevert from '../../helpers/EVMRevert';
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -12,15 +12,15 @@ contract('SafeERC20', function () {
   });
 
   it('should throw on failed transfer', async function () {
-    await this.helper.doFailingTransfer().should.be.rejectedWith(EVMThrow);
+    await this.helper.doFailingTransfer().should.be.rejectedWith(EVMRevert);
   });
 
   it('should throw on failed transferFrom', async function () {
-    await this.helper.doFailingTransferFrom().should.be.rejectedWith(EVMThrow);
+    await this.helper.doFailingTransferFrom().should.be.rejectedWith(EVMRevert);
   });
 
   it('should throw on failed approve', async function () {
-    await this.helper.doFailingApprove().should.be.rejectedWith(EVMThrow);
+    await this.helper.doFailingApprove().should.be.rejectedWith(EVMRevert);
   });
 
   it('should not throw on succeeding transfer', async function () {


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #

# 🚀 Description

Some contracts use `assert` to change for conditions instead of `require`. However assert should not be used for conditional checking but only for invariants, as it burns all gas on failure.

Quote from the Solidity docs (http://solidity.readthedocs.io/en/v0.4.21/control-structures.html#error-handling-assert-require-revert-and-exceptions): "Properly functioning code should never reach a failing assert statement; if this happens there is a bug in your contract which you should fix." 

The points where assert was replaced can fail and failure does not indicate a bug in the contract.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [ x ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [ x ] ✅ I've added tests where applicable to test my new functionality.
- [ x ] 📖 I've made sure that my contracts are well-documented.
- [ x ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
Unrelated lint issues where found.