### PR TITLE
remove admin functionality from RBAC.sol

### DIFF
--- a/contracts/crowdsale/distribution/RefundableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/RefundableCrowdsale.sol
@@ -22,7 +22,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
   RefundVault public vault;
 
   /**
-   * @dev Constructor, creates RefundVault. 
+   * @dev Constructor, creates RefundVault.
    * @param _goal Funding goal
    */
   function RefundableCrowdsale(uint256 _goal) public {
@@ -42,7 +42,7 @@ contract RefundableCrowdsale is FinalizableCrowdsale {
   }
 
   /**
-   * @dev Checks whether funding goal was reached. 
+   * @dev Checks whether funding goal was reached.
    * @return Whether funding goal was reached
    */
   function goalReached() public view returns (bool) {

--- a/contracts/mocks/RBACMock.sol
+++ b/contracts/mocks/RBACMock.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.8;
 
-import "../ownership/rbac/RBAC.sol";
+import "../ownership/rbac/RBACWithAdmin.sol";
 
 
-contract RBACMock is RBAC {
+contract RBACMock is RBACWithAdmin {
 
   string constant ROLE_ADVISOR = "advisor";
 

--- a/contracts/ownership/rbac/RBAC.sol
+++ b/contracts/ownership/rbac/RBAC.sol
@@ -7,8 +7,8 @@ import "./Roles.sol";
  * @title RBAC (Role-Based Access Control)
  * @author Matt Condon (@Shrugs)
  * @dev Stores and provides setters and getters for roles and addresses.
- *      Supports unlimited numbers of roles and addresses.
- *      See //contracts/mocks/RBACMock.sol for an example of usage.
+ * @dev Supports unlimited numbers of roles and addresses.
+ * @dev See //contracts/mocks/RBACMock.sol for an example of usage.
  * This RBAC method uses strings to key roles. It may be beneficial
  *  for you to write your own implementation of this interface using Enums or similar.
  * It's also recommended that you define constants in the contract, like ROLE_ADMIN below,
@@ -21,20 +21,6 @@ contract RBAC {
 
   event RoleAdded(address addr, string roleName);
   event RoleRemoved(address addr, string roleName);
-
-  /**
-   * A constant role name for indicating admins.
-   */
-  string public constant ROLE_ADMIN = "admin";
-
-  /**
-   * @dev constructor. Sets msg.sender as admin by default
-   */
-  function RBAC()
-    public
-  {
-    addRole(msg.sender, ROLE_ADMIN);
-  }
 
   /**
    * @dev reverts if addr does not have role
@@ -61,30 +47,6 @@ contract RBAC {
     returns (bool)
   {
     return roles[roleName].has(addr);
-  }
-
-  /**
-   * @dev add a role to an address
-   * @param addr address
-   * @param roleName the name of the role
-   */
-  function adminAddRole(address addr, string roleName)
-    onlyAdmin
-    public
-  {
-    addRole(addr, roleName);
-  }
-
-  /**
-   * @dev remove a role from an address
-   * @param addr address
-   * @param roleName the name of the role
-   */
-  function adminRemoveRole(address addr, string roleName)
-    onlyAdmin
-    public
-  {
-    removeRole(addr, roleName);
   }
 
   /**
@@ -119,16 +81,6 @@ contract RBAC {
   modifier onlyRole(string roleName)
   {
     checkRole(msg.sender, roleName);
-    _;
-  }
-
-  /**
-   * @dev modifier to scope access to admins
-   * // reverts
-   */
-  modifier onlyAdmin()
-  {
-    checkRole(msg.sender, ROLE_ADMIN);
     _;
   }
 

--- a/contracts/ownership/rbac/RBACWithAdmin.sol
+++ b/contracts/ownership/rbac/RBACWithAdmin.sol
@@ -1,0 +1,60 @@
+pragma solidity ^0.4.18;
+
+import "./RBAC.sol";
+
+
+/**
+ * @title RBACWithAdmin
+ * @author Matt Condon (@Shrugs)
+ * @dev It's recommended that you define constants in the contract,
+ * @dev like ROLE_ADMIN below, to avoid typos.
+ */
+contract RBACWithAdmin is RBAC {
+  /**
+   * A constant role name for indicating admins.
+   */
+  string public constant ROLE_ADMIN = "admin";
+
+  /**
+   * @dev modifier to scope access to admins
+   * // reverts
+   */
+  modifier onlyAdmin()
+  {
+    checkRole(msg.sender, ROLE_ADMIN);
+    _;
+  }
+
+  /**
+   * @dev constructor. Sets msg.sender as admin by default
+   */
+  function RBACWithAdmin()
+    public
+  {
+    addRole(msg.sender, ROLE_ADMIN);
+  }
+
+  /**
+   * @dev add a role to an address
+   * @param addr address
+   * @param roleName the name of the role
+   */
+  function adminAddRole(address addr, string roleName)
+    onlyAdmin
+    public
+  {
+    addRole(addr, roleName);
+  }
+
+  /**
+   * @dev remove a role from an address
+   * @param addr address
+   * @param roleName the name of the role
+   */
+  function adminRemoveRole(address addr, string roleName)
+    onlyAdmin
+    public
+  {
+    removeRole(addr, roleName);
+  }
+}


### PR DESCRIPTION
Fixes #802 

# 🚀 Description

separates the rbac admin functionality into a second contract. this is a breaking change.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).