### PR TITLE
Make ERC827 methods payable

### DIFF
--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -12,7 +12,11 @@ contract MessageHelper {
   }
 
   function buyMessage( bytes32 message, uint256 number, string text ) public payable returns (bool) {
-    emit Buy(message, number, text, msg.value);
+    emit Buy(
+      message,
+      number,
+      text,
+      msg.value);
     return true;
   }
 

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -20,9 +20,6 @@ contract MessageHelper {
     require(false);
   }
 
-  function failOnBuy() public {
-  }
-
   function call(address to, bytes data) public returns (bool) {
     // solium-disable-next-line security/no-low-level-calls
     if (to.call(data))

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -4,14 +4,23 @@ pragma solidity ^0.4.21;
 contract MessageHelper {
 
   event Show(bytes32 b32, uint256 number, string text);
+  event Buy(bytes32 b32, uint256 number, string text, uint256 value);
 
   function showMessage( bytes32 message, uint256 number, string text ) public returns (bool) {
     emit Show(message, number, text);
     return true;
   }
 
+  function buyMessage( bytes32 message, uint256 number, string text ) public payable returns (bool) {
+    emit Buy(message, number, text, msg.value);
+    return true;
+  }
+
   function fail() public {
     require(false);
+  }
+
+  function failOnBuy() public {
   }
 
   function call(address to, bytes data) public returns (bool) {

--- a/contracts/token/ERC827/ERC827.sol
+++ b/contracts/token/ERC827/ERC827.sol
@@ -12,8 +12,8 @@ import "../ERC20/ERC20.sol";
  * @dev approvals.
  */
 contract ERC827 is ERC20 {
-  function approveAndCall( address _spender, uint256 _value, bytes _data) public returns (bool);
-  function transferAndCall( address _to, uint256 _value, bytes _data) public returns (bool);
+  function approveAndCall( address _spender, uint256 _value, bytes _data) public payable returns (bool);
+  function transferAndCall( address _to, uint256 _value, bytes _data) public payable returns (bool);
   function transferFromAndCall(
     address _from,
     address _to,
@@ -21,5 +21,6 @@ contract ERC827 is ERC20 {
     bytes _data
   )
     public
+    payable
     returns (bool);
 }

--- a/contracts/token/ERC827/ERC827Token.sol
+++ b/contracts/token/ERC827/ERC827Token.sol
@@ -34,12 +34,12 @@ contract ERC827Token is ERC827, StandardToken {
    *
    * @return true if the call function was executed successfully
    */
-  function approveAndCall(address _spender, uint256 _value, bytes _data) public returns (bool) {
+  function approveAndCall(address _spender, uint256 _value, bytes _data) public payable returns (bool) {
     require(_spender != address(this));
 
     super.approve(_spender, _value);
 
-    require(_spender.call(_data));
+    require(_spender.call.value(msg.value)(_data));
 
     return true;
   }
@@ -54,12 +54,12 @@ contract ERC827Token is ERC827, StandardToken {
    *
    * @return true if the call function was executed successfully
    */
-  function transferAndCall(address _to, uint256 _value, bytes _data) public returns (bool) {
+  function transferAndCall(address _to, uint256 _value, bytes _data) public payable returns (bool) {
     require(_to != address(this));
 
     super.transfer(_to, _value);
 
-    require(_to.call(_data));
+    require(_to.call.value(msg.value)(_data));
     return true;
   }
 
@@ -80,13 +80,13 @@ contract ERC827Token is ERC827, StandardToken {
     uint256 _value,
     bytes _data
   )
-    public returns (bool)
+    public payable returns (bool)
   {
     require(_to != address(this));
 
     super.transferFrom(_from, _to, _value);
 
-    require(_to.call(_data));
+    require(_to.call.value(msg.value)(_data));
     return true;
   }
 
@@ -103,12 +103,12 @@ contract ERC827Token is ERC827, StandardToken {
    * @param _addedValue The amount of tokens to increase the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function increaseApprovalAndCall(address _spender, uint _addedValue, bytes _data) public returns (bool) {
+  function increaseApprovalAndCall(address _spender, uint _addedValue, bytes _data) public payable returns (bool) {
     require(_spender != address(this));
 
     super.increaseApproval(_spender, _addedValue);
 
-    require(_spender.call(_data));
+    require(_spender.call.value(msg.value)(_data));
 
     return true;
   }
@@ -126,12 +126,12 @@ contract ERC827Token is ERC827, StandardToken {
    * @param _subtractedValue The amount of tokens to decrease the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function decreaseApprovalAndCall(address _spender, uint _subtractedValue, bytes _data) public returns (bool) {
+  function decreaseApprovalAndCall(address _spender, uint _subtractedValue, bytes _data) public payable returns (bool) {
     require(_spender != address(this));
 
     super.decreaseApproval(_spender, _subtractedValue);
 
-    require(_spender.call(_data));
+    require(_spender.call.value(msg.value)(_data));
 
     return true;
   }

--- a/contracts/token/ERC827/ERC827Token.sol
+++ b/contracts/token/ERC827/ERC827Token.sol
@@ -39,6 +39,7 @@ contract ERC827Token is ERC827, StandardToken {
 
     super.approve(_spender, _value);
 
+    // solium-disable-next-line security/no-call-value
     require(_spender.call.value(msg.value)(_data));
 
     return true;
@@ -59,6 +60,7 @@ contract ERC827Token is ERC827, StandardToken {
 
     super.transfer(_to, _value);
 
+    // solium-disable-next-line security/no-call-value
     require(_to.call.value(msg.value)(_data));
     return true;
   }
@@ -86,6 +88,7 @@ contract ERC827Token is ERC827, StandardToken {
 
     super.transferFrom(_from, _to, _value);
 
+    // solium-disable-next-line security/no-call-value
     require(_to.call.value(msg.value)(_data));
     return true;
   }
@@ -108,6 +111,7 @@ contract ERC827Token is ERC827, StandardToken {
 
     super.increaseApproval(_spender, _addedValue);
 
+    // solium-disable-next-line security/no-call-value
     require(_spender.call.value(msg.value)(_data));
 
     return true;
@@ -131,6 +135,7 @@ contract ERC827Token is ERC827, StandardToken {
 
     super.decreaseApproval(_spender, _subtractedValue);
 
+    // solium-disable-next-line security/no-call-value
     require(_spender.call.value(msg.value)(_data));
 
     return true;

--- a/test/token/ERC827/ERC827Token.js
+++ b/test/token/ERC827/ERC827Token.js
@@ -118,12 +118,9 @@ contract('ERC827 Token', function (accounts) {
         const extraData = message.contract.buyMessage.getData(
           web3.toHex(123456), 666, 'Transfer Done'
         );
-        const abiMethod = findMethod(token.abi, 'transfer', 'address,uint256,bytes');
-        const transferData = ethjsABI.encodeMethod(abiMethod,
-          [message.contract.address, 100, extraData]
-        );
-        const transaction = await token.sendTransaction(
-          { from: accounts[0], data: transferData, value: 1000 }
+
+        const transaction = await token.transferAndCall(
+          message.contract.address, 100, extraData, { from: accounts[0], value: 1000 }
         );
 
         assert.equal(2, transaction.receipt.logs.length);
@@ -145,12 +142,8 @@ contract('ERC827 Token', function (accounts) {
           web3.toHex(123456), 666, 'Transfer Done'
         );
 
-        const abiMethod = findMethod(token.abi, 'approve', 'address,uint256,bytes');
-        const approveData = ethjsABI.encodeMethod(abiMethod,
-          [message.contract.address, 100, extraData]
-        );
-        const transaction = await token.sendTransaction(
-          { from: accounts[0], data: approveData, value: 1000 }
+        const transaction = await token.approveAndCall(
+          message.contract.address, 100, extraData, { from: accounts[0], value: 1000 }
         );
 
         assert.equal(2, transaction.receipt.logs.length);
@@ -177,12 +170,8 @@ contract('ERC827 Token', function (accounts) {
           await token.allowance(accounts[0], message.contract.address)
         );
 
-        const abiMethod = findMethod(token.abi, 'increaseApproval', 'address,uint256,bytes');
-        const increaseApprovalData = ethjsABI.encodeMethod(abiMethod,
-          [message.contract.address, 50, extraData]
-        );
-        const transaction = await token.sendTransaction(
-          { from: accounts[0], data: increaseApprovalData, value: 1000 }
+        const transaction = await token.increaseApprovalAndCall(
+          message.contract.address, 50, extraData, { from: accounts[0], value: 1000 }
         );
 
         assert.equal(2, transaction.receipt.logs.length);
@@ -210,12 +199,8 @@ contract('ERC827 Token', function (accounts) {
           web3.toHex(123456), 666, 'Transfer Done'
         );
 
-        const abiMethod = findMethod(token.abi, 'decreaseApproval', 'address,uint256,bytes');
-        const decreaseApprovalData = ethjsABI.encodeMethod(abiMethod,
-          [message.contract.address, 60, extraData]
-        );
-        const transaction = await token.sendTransaction(
-          { from: accounts[0], data: decreaseApprovalData, value: 1000 }
+        const transaction = await token.decreaseApprovalAndCall(
+          message.contract.address, 60, extraData, { from: accounts[0], value: 1000 }
         );
 
         assert.equal(2, transaction.receipt.logs.length);
@@ -243,12 +228,8 @@ contract('ERC827 Token', function (accounts) {
           await token.allowance(accounts[0], accounts[1])
         );
 
-        const abiMethod = findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes');
-        const transferFromData = ethjsABI.encodeMethod(abiMethod,
-          [accounts[0], message.contract.address, 100, extraData]
-        );
-        const transaction = await token.sendTransaction(
-          { from: accounts[1], data: transferFromData, value: 1000 }
+        const transaction = await token.transferFromAndCall(
+          accounts[0], message.contract.address, 100, extraData, { from: accounts[1], value: 1000 }
         );
 
         assert.equal(2, transaction.receipt.logs.length);
@@ -268,12 +249,8 @@ contract('ERC827 Token', function (accounts) {
         web3.toHex(123456), 666, 'Transfer Done'
       );
 
-      const abiMethod = findMethod(token.abi, 'approve', 'address,uint256,bytes');
-      const approveData = ethjsABI.encodeMethod(abiMethod,
-        [message.contract.address, 10, extraData]
-      );
-      await token.sendTransaction(
-        { from: accounts[0], data: approveData, value: 1000 }
+      await token.approveAndCall(
+        message.contract.address, 10, extraData, { from: accounts[0], value: 1000 }
       ).should.be.rejectedWith(EVMRevert);
 
       // approval should not have gone through so allowance is still 0
@@ -290,12 +267,8 @@ contract('ERC827 Token', function (accounts) {
         web3.toHex(123456), 666, 'Transfer Done'
       );
 
-      const abiMethod = findMethod(token.abi, 'transfer', 'address,uint256,bytes');
-      const transferData = ethjsABI.encodeMethod(abiMethod,
-        [message.contract.address, 10, extraData]
-      );
-      await token.sendTransaction(
-        { from: accounts[0], data: transferData, value: 1000 }
+      await token.transferAndCall(
+        message.contract.address, 10, extraData, { from: accounts[0], value: 1000 }
       ).should.be.rejectedWith(EVMRevert);
 
       // transfer should not have gone through, so balance is still 0
@@ -314,12 +287,8 @@ contract('ERC827 Token', function (accounts) {
 
       await token.approve(accounts[1], 10, { from: accounts[2] });
 
-      const abiMethod = findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes');
-      const transferFromData = ethjsABI.encodeMethod(abiMethod,
-        [accounts[2], message.contract.address, 10, extraData]
-      );
-      await token.sendTransaction(
-        { from: accounts[1], data: transferFromData, value: 1000 }
+      await token.transferFromAndCall(
+        accounts[2], message.contract.address, 10, extraData, { from: accounts[2], value: 1000 }
       ).should.be.rejectedWith(EVMRevert);
 
       // transferFrom should have failed so balance is still 0 but allowance is 10

--- a/test/token/ERC827/ERC827Token.js
+++ b/test/token/ERC827/ERC827Token.js
@@ -264,7 +264,9 @@ contract('ERC827 Token', function (accounts) {
     it('should revert funds of failure inside approve (with data)', async function () {
       const message = await Message.new();
 
-      const extraData = message.contract.failOnBuy.getData();
+      const extraData = message.contract.showMessage.getData(
+        web3.toHex(123456), 666, 'Transfer Done'
+      );
 
       const abiMethod = findMethod(token.abi, 'approve', 'address,uint256,bytes');
       const approveData = ethjsABI.encodeMethod(abiMethod,
@@ -284,7 +286,9 @@ contract('ERC827 Token', function (accounts) {
     it('should revert funds of failure inside transfer (with data)', async function () {
       const message = await Message.new();
 
-      const extraData = message.contract.failOnBuy.getData();
+      const extraData = message.contract.showMessage.getData(
+        web3.toHex(123456), 666, 'Transfer Done'
+      );
 
       const abiMethod = findMethod(token.abi, 'transfer', 'address,uint256,bytes');
       const transferData = ethjsABI.encodeMethod(abiMethod,
@@ -304,7 +308,9 @@ contract('ERC827 Token', function (accounts) {
     it('should revert funds of failure inside transferFrom (with data)', async function () {
       const message = await Message.new();
 
-      const extraData = message.contract.failOnBuy.getData();
+      const extraData = message.contract.showMessage.getData(
+        web3.toHex(123456), 666, 'Transfer Done'
+      );
 
       await token.approve(accounts[1], 10, { from: accounts[2] });
 

--- a/test/token/ERC827/ERC827Token.js
+++ b/test/token/ERC827/ERC827Token.js
@@ -111,6 +111,221 @@ contract('ERC827 Token', function (accounts) {
 
   describe('Test ERC827 methods', function () {
     it(
+      'should allow payment through transfer'
+      , async function () {
+        const message = await Message.new();
+
+        const extraData = message.contract.buyMessage.getData(
+          web3.toHex(123456), 666, 'Transfer Done'
+        );
+        const abiMethod = findMethod(token.abi, 'transfer', 'address,uint256,bytes');
+        const transferData = ethjsABI.encodeMethod(abiMethod,
+          [message.contract.address, 100, extraData]
+        );
+        const transaction = await token.sendTransaction(
+          { from: accounts[0], data: transferData, value: 1000 }
+        );
+
+        assert.equal(2, transaction.receipt.logs.length);
+
+        new BigNumber(100).should.be.bignumber.equal(
+          await token.balanceOf(message.contract.address)
+        );
+        new BigNumber(1000).should.be.bignumber.equal(
+          await web3.eth.getBalance(message.contract.address)
+        );
+      });
+
+    it(
+      'should allow payment through approve'
+      , async function () {
+        const message = await Message.new();
+
+        const extraData = message.contract.buyMessage.getData(
+          web3.toHex(123456), 666, 'Transfer Done'
+        );
+
+        const abiMethod = findMethod(token.abi, 'approve', 'address,uint256,bytes');
+        const approveData = ethjsABI.encodeMethod(abiMethod,
+          [message.contract.address, 100, extraData]
+        );
+        const transaction = await token.sendTransaction(
+          { from: accounts[0], data: approveData, value: 1000 }
+        );
+
+        assert.equal(2, transaction.receipt.logs.length);
+
+        new BigNumber(100).should.be.bignumber.equal(
+          await token.allowance(accounts[0], message.contract.address)
+        );
+        new BigNumber(1000).should.be.bignumber.equal(
+          await web3.eth.getBalance(message.contract.address)
+        );
+      });
+
+    it(
+      'should allow payment through increaseApproval'
+      , async function () {
+        const message = await Message.new();
+
+        const extraData = message.contract.buyMessage.getData(
+          web3.toHex(123456), 666, 'Transfer Done'
+        );
+
+        await token.approve(message.contract.address, 10);
+        new BigNumber(10).should.be.bignumber.equal(
+          await token.allowance(accounts[0], message.contract.address)
+        );
+
+        const abiMethod = findMethod(token.abi, 'increaseApproval', 'address,uint256,bytes');
+        const increaseApprovalData = ethjsABI.encodeMethod(abiMethod,
+          [message.contract.address, 50, extraData]
+        );
+        const transaction = await token.sendTransaction(
+          { from: accounts[0], data: increaseApprovalData, value: 1000 }
+        );
+
+        assert.equal(2, transaction.receipt.logs.length);
+
+        new BigNumber(60).should.be.bignumber.equal(
+          await token.allowance(accounts[0], message.contract.address)
+        );
+        new BigNumber(1000).should.be.bignumber.equal(
+          await web3.eth.getBalance(message.contract.address)
+        );
+      });
+
+    it(
+      'should allow payment through decreaseApproval'
+      , async function () {
+        const message = await Message.new();
+
+        await token.approve(message.contract.address, 100);
+
+        new BigNumber(100).should.be.bignumber.equal(
+          await token.allowance(accounts[0], message.contract.address)
+        );
+
+        const extraData = message.contract.buyMessage.getData(
+          web3.toHex(123456), 666, 'Transfer Done'
+        );
+
+        const abiMethod = findMethod(token.abi, 'decreaseApproval', 'address,uint256,bytes');
+        const decreaseApprovalData = ethjsABI.encodeMethod(abiMethod,
+          [message.contract.address, 60, extraData]
+        );
+        const transaction = await token.sendTransaction(
+          { from: accounts[0], data: decreaseApprovalData, value: 1000 }
+        );
+
+        assert.equal(2, transaction.receipt.logs.length);
+
+        new BigNumber(40).should.be.bignumber.equal(
+          await token.allowance(accounts[0], message.contract.address)
+        );
+        new BigNumber(1000).should.be.bignumber.equal(
+          await web3.eth.getBalance(message.contract.address)
+        );
+      });
+
+    it(
+      'should allow payment through transferFrom'
+      , async function () {
+        const message = await Message.new();
+
+        const extraData = message.contract.buyMessage.getData(
+          web3.toHex(123456), 666, 'Transfer Done'
+        );
+
+        await token.approve(accounts[1], 100, { from: accounts[0] });
+
+        new BigNumber(100).should.be.bignumber.equal(
+          await token.allowance(accounts[0], accounts[1])
+        );
+
+        const abiMethod = findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes');
+        const transferFromData = ethjsABI.encodeMethod(abiMethod,
+          [accounts[0], message.contract.address, 100, extraData]
+        );
+        const transaction = await token.sendTransaction(
+          { from: accounts[1], data: transferFromData, value: 1000 }
+        );
+
+        assert.equal(2, transaction.receipt.logs.length);
+
+        new BigNumber(100).should.be.bignumber.equal(
+          await token.balanceOf(message.contract.address)
+        );
+        new BigNumber(1000).should.be.bignumber.equal(
+          await web3.eth.getBalance(message.contract.address)
+        );
+      });
+
+    it('should revert funds of failure inside approve (with data)', async function () {
+      const message = await Message.new();
+
+      const extraData = message.contract.failOnBuy.getData();
+
+      const abiMethod = findMethod(token.abi, 'approve', 'address,uint256,bytes');
+      const approveData = ethjsABI.encodeMethod(abiMethod,
+        [message.contract.address, 10, extraData]
+      );
+      await token.sendTransaction(
+        { from: accounts[0], data: approveData, value: 1000 }
+      ).should.be.rejectedWith(EVMRevert);
+
+      // approval should not have gone through so allowance is still 0
+      new BigNumber(0).should.be.bignumber
+        .equal(await token.allowance(accounts[1], message.contract.address));
+      new BigNumber(0).should.be.bignumber
+        .equal(await web3.eth.getBalance(message.contract.address));
+    });
+
+    it('should revert funds of failure inside transfer (with data)', async function () {
+      const message = await Message.new();
+
+      const extraData = message.contract.failOnBuy.getData();
+
+      const abiMethod = findMethod(token.abi, 'transfer', 'address,uint256,bytes');
+      const transferData = ethjsABI.encodeMethod(abiMethod,
+        [message.contract.address, 10, extraData]
+      );
+      await token.sendTransaction(
+        { from: accounts[0], data: transferData, value: 1000 }
+      ).should.be.rejectedWith(EVMRevert);
+
+      // transfer should not have gone through, so balance is still 0
+      new BigNumber(0).should.be.bignumber
+        .equal(await token.balanceOf(message.contract.address));
+      new BigNumber(0).should.be.bignumber
+        .equal(await web3.eth.getBalance(message.contract.address));
+    });
+
+    it('should revert funds of failure inside transferFrom (with data)', async function () {
+      const message = await Message.new();
+
+      const extraData = message.contract.failOnBuy.getData();
+
+      await token.approve(accounts[1], 10, { from: accounts[2] });
+
+      const abiMethod = findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes');
+      const transferFromData = ethjsABI.encodeMethod(abiMethod,
+        [accounts[2], message.contract.address, 10, extraData]
+      );
+      await token.sendTransaction(
+        { from: accounts[1], data: transferFromData, value: 1000 }
+      ).should.be.rejectedWith(EVMRevert);
+
+      // transferFrom should have failed so balance is still 0 but allowance is 10
+      new BigNumber(10).should.be.bignumber
+        .equal(await token.allowance(accounts[2], accounts[1]));
+      new BigNumber(0).should.be.bignumber
+        .equal(await token.balanceOf(message.contract.address));
+      new BigNumber(0).should.be.bignumber
+        .equal(await web3.eth.getBalance(message.contract.address));
+    });
+
+    it(
       'should return correct balances after transfer (with data) and show the event on receiver contract'
       , async function () {
         const message = await Message.new();


### PR DESCRIPTION
# 🚀 Description

Make all ERC827 methods `payable` to pass-through value. I wanna be able to combine several actions in single tx:
1. Approve MyToken to MySmartContract
2. Buy MyToken for ETH in Bancor smart contract
3. MySmartContract to call transferFrom to receive MyTokens

Remarks:
- ~Tell me if you are going to merge and I'll add related tests.~ (added in https://github.com/OpenZeppelin/zeppelin-solidity/pull/838/commits/a897f11d78f136e3d18b19f8080a5d7f0d9868c2)
- ~Linter started to give errors.~ (fixed in https://github.com/OpenZeppelin/zeppelin-solidity/pull/838/commits/4c2852425f2e6215a07355dd88d784aeb047c133)

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).