### PR TITLE
fix potential overflow on decimals

### DIFF
--- a/contracts/token/ERC20/DetailedERC20.sol
+++ b/contracts/token/ERC20/DetailedERC20.sol
@@ -6,9 +6,9 @@ import "./ERC20.sol";
 contract DetailedERC20 is ERC20 {
   string public name;
   string public symbol;
-  uint8 public decimals;
+  uint256 public decimals;
 
-  function DetailedERC20(string _name, string _symbol, uint8 _decimals) public {
+  function DetailedERC20(string _name, string _symbol, uint256 _decimals) public {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

# 🚀 Description

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

If a contract inherits "DetailedERC20.sol", there is a potential overflow on `totalSupply`
```
uint256 private _totalSupply;
function NewToken(string _name, string _symbol, uint8 _decimals) public DetailedERC20(_name, _symbol, _decimals) {
        _totalSupply = 20 * (10 ** decimals);
        balances[msg.sender] = _totalSupply;
    }
function totalSupply() public view returns (uint256) {
        return _totalSupply;
    }
```
Because `decimals` is `uint8`, `10 ** decimals` is also `uint8`. As example above `_totalSupply` will overflow when `10 ** decimals` is bigger than 2^8-1.

A workaround will be using `10 ** uint256(decimals)`, but it is not intuitive for developers to write a contract.


<!-- 3. Before submitting, please review the following checklist: -->

- [ ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).