### PR TITLE
Removing obsolete comment - explicit check in place

### DIFF
--- a/contracts/token/ERC20/BasicToken.sol
+++ b/contracts/token/ERC20/BasicToken.sol
@@ -32,7 +32,6 @@ contract BasicToken is ERC20Basic {
     require(_to != address(0));
     require(_value <= balances[msg.sender]);
 
-    // SafeMath.sub will throw if there is not enough balance.
     balances[msg.sender] = balances[msg.sender].sub(_value);
     balances[_to] = balances[_to].add(_value);
     Transfer(msg.sender, _to, _value);


### PR DESCRIPTION
Back in a day we were relying on `SafeMath` doing the job and throwing an error - see the commit - https://github.com/OpenZeppelin/zeppelin-solidity/commit/aad25205cdc54243ccfe82a1bd35c08904d2a152

Now there is explicit check in place `require(_value <= balances[msg.sender]);` - no longer need for comment.

`#trivial`

*(although made me think as one repos I was working was using `1.2.0` and no explicit checks made me think)*