### PR TITLE
Remove unnecessary import from ERC721Token.sol

### DIFF
--- a/contracts/token/ERC721/ERC721Token.sol
+++ b/contracts/token/ERC721/ERC721Token.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.18;
 
 import "./ERC721.sol";
-import "./DeprecatedERC721.sol";
 import "./ERC721BasicToken.sol";
 
 


### PR DESCRIPTION
# 🚀 Description

Theres an extra import in ERC721Token.sol and the DeprecatedERC721.sol isn't implemented or necessary. Removing this import will reduce a file dependency in this contract.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](/docs/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).