### PR TITLE
Avoid deprecated direct event call by prefixing with emit calls

### DIFF
--- a/contracts/Bounty.sol
+++ b/contracts/Bounty.sol
@@ -30,7 +30,7 @@ contract Bounty is PullPayment, Destructible {
   function createTarget() public returns(Target) {
     Target target = Target(deployContract());
     researchers[target] = msg.sender;
-    TargetCreated(target);
+    emit TargetCreated(target);
     return target;
   }
 

--- a/contracts/crowdsale/Crowdsale.sol
+++ b/contracts/crowdsale/Crowdsale.sol
@@ -82,7 +82,7 @@ contract Crowdsale {
     weiRaised = weiRaised.add(weiAmount);
 
     _processPurchase(_beneficiary, tokens);
-    TokenPurchase(msg.sender, _beneficiary, weiAmount, tokens);
+    emit TokenPurchase(msg.sender, _beneficiary, weiAmount, tokens);
 
     _updatePurchasingState(_beneficiary, weiAmount);
 

--- a/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
+++ b/contracts/crowdsale/distribution/FinalizableCrowdsale.sol
@@ -26,7 +26,7 @@ contract FinalizableCrowdsale is TimedCrowdsale, Ownable {
     require(hasClosed());
 
     finalization();
-    Finalized();
+    emit Finalized();
 
     isFinalized = true;
   }

--- a/contracts/crowdsale/distribution/utils/RefundVault.sol
+++ b/contracts/crowdsale/distribution/utils/RefundVault.sol
@@ -43,14 +43,14 @@ contract RefundVault is Ownable {
   function close() onlyOwner public {
     require(state == State.Active);
     state = State.Closed;
-    Closed();
+    emit Closed();
     wallet.transfer(this.balance);
   }
 
   function enableRefunds() onlyOwner public {
     require(state == State.Active);
     state = State.Refunding;
-    RefundsEnabled();
+    emit RefundsEnabled();
   }
 
   /**
@@ -61,6 +61,6 @@ contract RefundVault is Ownable {
     uint256 depositedValue = deposited[investor];
     deposited[investor] = 0;
     investor.transfer(depositedValue);
-    Refunded(investor, depositedValue);
+    emit Refunded(investor, depositedValue);
   }
 }

--- a/contracts/examples/SimpleSavingsWallet.sol
+++ b/contracts/examples/SimpleSavingsWallet.sol
@@ -25,7 +25,7 @@ contract SimpleSavingsWallet is Heritable {
    * @dev wallet can receive funds.
    */
   function () public payable {
-    Received(msg.sender, msg.value, this.balance);
+    emit Received(msg.sender, msg.value, this.balance);
   }
 
   /**
@@ -35,6 +35,6 @@ contract SimpleSavingsWallet is Heritable {
     require(payee != 0 && payee != address(this));
     require(amount > 0);
     payee.transfer(amount);
-    Sent(payee, amount, this.balance);
+    emit Sent(payee, amount, this.balance);
   }
 }

--- a/contracts/lifecycle/Pausable.sol
+++ b/contracts/lifecycle/Pausable.sol
@@ -36,7 +36,7 @@ contract Pausable is Ownable {
    */
   function pause() onlyOwner whenNotPaused public {
     paused = true;
-    Pause();
+    emit Pause();
   }
 
   /**
@@ -44,6 +44,6 @@ contract Pausable is Ownable {
    */
   function unpause() onlyOwner whenPaused public {
     paused = false;
-    Unpause();
+    emit Unpause();
   }
 }

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -16,7 +16,7 @@ contract ERC721ReceiverMock is ERC721Receiver {
 
   function onERC721Received(address _address, uint256 _tokenId, bytes _data) public returns(bytes4) {
     require(!reverts);
-    Received(_address, _tokenId, _data, msg.gas);
+    emit Received(_address, _tokenId, _data, msg.gas);
     return retval;
   }
 }

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -6,7 +6,7 @@ contract MessageHelper {
   event Show(bytes32 b32, uint256 number, string text);
 
   function showMessage( bytes32 message, uint256 number, string text ) public returns (bool) {
-    Show(message, number, text);
+    emit Show(message, number, text);
     return true;
   }
 

--- a/contracts/ownership/Heritable.sol
+++ b/contracts/ownership/Heritable.sol
@@ -46,7 +46,7 @@ contract Heritable is Ownable {
   function setHeir(address newHeir) public onlyOwner {
     require(newHeir != owner);
     heartbeat();
-    HeirChanged(owner, newHeir);
+    emit HeirChanged(owner, newHeir);
     heir_ = newHeir;
   }
 
@@ -80,7 +80,7 @@ contract Heritable is Ownable {
    */
   function proclaimDeath() public onlyHeir {
     require(ownerLives());
-    OwnerProclaimedDead(owner, heir_, timeOfDeath_);
+    emit OwnerProclaimedDead(owner, heir_, timeOfDeath_);
     timeOfDeath_ = block.timestamp;
   }
 
@@ -88,7 +88,7 @@ contract Heritable is Ownable {
    * @dev Owner can send a heartbeat if they were mistakenly pronounced dead.
    */
   function heartbeat() public onlyOwner {
-    OwnerHeartbeated(owner);
+    emit OwnerHeartbeated(owner);
     timeOfDeath_ = 0;
   }
 
@@ -98,8 +98,8 @@ contract Heritable is Ownable {
   function claimHeirOwnership() public onlyHeir {
     require(!ownerLives());
     require(block.timestamp >= timeOfDeath_ + heartbeatTimeout_);
-    OwnershipTransferred(owner, heir_);
-    HeirOwnershipClaimed(owner, heir_);
+    emit OwnershipTransferred(owner, heir_);
+    emit HeirOwnershipClaimed(owner, heir_);
     owner = heir_;
     timeOfDeath_ = 0;
   }

--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -35,7 +35,7 @@ contract Ownable {
    */
   function transferOwnership(address newOwner) public onlyOwner {
     require(newOwner != address(0));
-    OwnershipTransferred(owner, newOwner);
+    emit OwnershipTransferred(owner, newOwner);
     owner = newOwner;
   }
 

--- a/contracts/ownership/Whitelist.sol
+++ b/contracts/ownership/Whitelist.sol
@@ -31,7 +31,7 @@ contract Whitelist is Ownable {
   function addAddressToWhitelist(address addr) onlyOwner public returns(bool success) {
     if (!whitelist[addr]) {
       whitelist[addr] = true;
-      WhitelistedAddressAdded(addr);
+      emit WhitelistedAddressAdded(addr);
       success = true; 
     }
   }
@@ -59,7 +59,7 @@ contract Whitelist is Ownable {
   function removeAddressFromWhitelist(address addr) onlyOwner public returns(bool success) {
     if (whitelist[addr]) {
       whitelist[addr] = false;
-      WhitelistedAddressRemoved(addr);
+      emit WhitelistedAddressRemoved(addr);
       success = true;
     }
   }

--- a/contracts/ownership/rbac/RBAC.sol
+++ b/contracts/ownership/rbac/RBAC.sol
@@ -58,7 +58,7 @@ contract RBAC {
     internal
   {
     roles[roleName].add(addr);
-    RoleAdded(addr, roleName);
+    emit RoleAdded(addr, roleName);
   }
 
   /**
@@ -70,7 +70,7 @@ contract RBAC {
     internal
   {
     roles[roleName].remove(addr);
-    RoleRemoved(addr, roleName);
+    emit RoleRemoved(addr, roleName);
   }
 
   /**

--- a/contracts/token/ERC20/BasicToken.sol
+++ b/contracts/token/ERC20/BasicToken.sol
@@ -34,7 +34,7 @@ contract BasicToken is ERC20Basic {
 
     balances[msg.sender] = balances[msg.sender].sub(_value);
     balances[_to] = balances[_to].add(_value);
-    Transfer(msg.sender, _to, _value);
+    emit Transfer(msg.sender, _to, _value);
     return true;
   }
 

--- a/contracts/token/ERC20/BurnableToken.sol
+++ b/contracts/token/ERC20/BurnableToken.sol
@@ -23,7 +23,7 @@ contract BurnableToken is BasicToken {
     address burner = msg.sender;
     balances[burner] = balances[burner].sub(_value);
     totalSupply_ = totalSupply_.sub(_value);
-    Burn(burner, _value);
+    emit Burn(burner, _value);
     Transfer(burner, address(0), _value);
   }
 }

--- a/contracts/token/ERC20/MintableToken.sol
+++ b/contracts/token/ERC20/MintableToken.sol
@@ -31,7 +31,7 @@ contract MintableToken is StandardToken, Ownable {
   function mint(address _to, uint256 _amount) onlyOwner canMint public returns (bool) {
     totalSupply_ = totalSupply_.add(_amount);
     balances[_to] = balances[_to].add(_amount);
-    Mint(_to, _amount);
+    emit Mint(_to, _amount);
     Transfer(address(0), _to, _amount);
     return true;
   }
@@ -42,7 +42,7 @@ contract MintableToken is StandardToken, Ownable {
    */
   function finishMinting() onlyOwner canMint public returns (bool) {
     mintingFinished = true;
-    MintFinished();
+    emit MintFinished();
     return true;
   }
 }

--- a/contracts/token/ERC20/StandardToken.sol
+++ b/contracts/token/ERC20/StandardToken.sol
@@ -30,7 +30,7 @@ contract StandardToken is ERC20, BasicToken {
     balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);
     allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
-    Transfer(_from, _to, _value);
+    emit Transfer(_from, _to, _value);
     return true;
   }
 
@@ -46,7 +46,7 @@ contract StandardToken is ERC20, BasicToken {
    */
   function approve(address _spender, uint256 _value) public returns (bool) {
     allowed[msg.sender][_spender] = _value;
-    Approval(msg.sender, _spender, _value);
+    emit Approval(msg.sender, _spender, _value);
     return true;
   }
 
@@ -72,7 +72,7 @@ contract StandardToken is ERC20, BasicToken {
    */
   function increaseApproval(address _spender, uint _addedValue) public returns (bool) {
     allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
-    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
     return true;
   }
 
@@ -93,7 +93,7 @@ contract StandardToken is ERC20, BasicToken {
     } else {
       allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
     }
-    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
     return true;
   }
 

--- a/contracts/token/ERC20/TokenVesting.sol
+++ b/contracts/token/ERC20/TokenVesting.sol
@@ -72,7 +72,7 @@ contract TokenVesting is Ownable {
 
     token.safeTransfer(beneficiary, unreleased);
 
-    Released(unreleased);
+    emit Released(unreleased);
   }
 
   /**
@@ -93,7 +93,7 @@ contract TokenVesting is Ownable {
 
     token.safeTransfer(owner, refund);
 
-    Revoked();
+    emit Revoked();
   }
 
   /**


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. **Does this close any open issues?** If so, list them here. If not, remove the `Fixes #` line. -->

Fixes #807 

# 🚀 Description

An initial fix that prepends (hopefully all!) event calls with the new emit syntax.

<!-- 2. Describe the changes introduced in this pull request -->
<!--    Include any context necessary for understanding the PR's purpose. -->

<!-- 3. Before submitting, please review the following checklist: -->

- [ ] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [ ] ✅ I've added tests where applicable to test my new functionality.
- [ ] 📖 I've made sure that my contracts are well-documented.
- [ ] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
