### PR TITLE
Change MerkleProof interface to take array of bytes32

### DIFF
--- a/contracts/MerkleProof.sol
+++ b/contracts/MerkleProof.sol
@@ -14,21 +14,11 @@ library MerkleProof {
    * @param _root Merkle root
    * @param _leaf Leaf of Merkle tree
    */
-  function verifyProof(bytes _proof, bytes32 _root, bytes32 _leaf) public pure returns (bool) {
-    // Check if proof length is a multiple of 32
-    if (_proof.length % 32 != 0) {
-      return false;
-    }
-
-    bytes32 proofElement;
+  function verifyProof(bytes32[] _proof, bytes32 _root, bytes32 _leaf) public pure returns (bool) {
     bytes32 computedHash = _leaf;
 
-    for (uint256 i = 32; i <= _proof.length; i += 32) {
-      // solium-disable-next-line security/no-inline-assembly
-      assembly {
-        // Load the current element of the proof
-        proofElement := mload(add(_proof, i))
-      }
+    for (uint256 i = 0; i < _proof.length; i++) {
+      bytes32 proofElement = _proof[i];
 
       if (computedHash < proofElement) {
         // Hash(current computed hash + current element of the proof)

--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -79,7 +79,7 @@ export default class MerkleTree {
   getHexProof (el) {
     const proof = this.getProof(el);
 
-    return this.bufArrToHex(proof);
+    return this.bufArrToHexArr(proof);
   }
 
   getPairElement (idx, layer) {
@@ -117,12 +117,12 @@ export default class MerkleTree {
     });
   }
 
-  bufArrToHex (arr) {
+  bufArrToHexArr (arr) {
     if (arr.some(el => !Buffer.isBuffer(el))) {
       throw new Error('Array is not an array of buffers');
     }
 
-    return '0x' + arr.map(el => el.toString('hex')).join('');
+    return arr.map(el => '0x' + el.toString('hex'));
   }
 
   sortAndConcat (...args) {


### PR DESCRIPTION
Changes the signature of `verifyProof` to take the proof as a `bytes32[]` instead of `bytes`. I think this better represents what the proof is (an array of hashes), and it also allows us to get rid of the one line of assembly that was necessary to extract 256-bit words from an array of bytes.

@yondonfu Since you wrote the contract originally would you mind explaining if there was a rationale for the previous interface, and seeing if this new interface makes sense to you? Thanks a lot!

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
