### PR TITLE
feat: add RBACOwnable to implement Ownable with RBAC

### DIFF
--- a/contracts/examples/RBACWithAdmin.sol
+++ b/contracts/examples/RBACWithAdmin.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import "./RBAC.sol";
+import "../ownership/rbac/RBAC.sol";
 
 
 /**
@@ -8,6 +8,11 @@ import "./RBAC.sol";
  * @author Matt Condon (@Shrugs)
  * @dev It's recommended that you define constants in the contract,
  * @dev like ROLE_ADMIN below, to avoid typos.
+ * @dev This contract uses RBAC to create a contract that can be managed by one or more
+ * @dev admins. These admins have free reign to reassign any and all roles in the system
+ * @dev which means it's probably not a great idea for production, but it easy to use
+ * @dev to play around. In real life, you'd want a highly-specific API that roles can
+ * @dev use to manage resources. See RBACOwnable.sol for an example of a specific API.
  */
 contract RBACWithAdmin is RBAC {
   /**

--- a/contracts/mocks/RBACMock.sol
+++ b/contracts/mocks/RBACMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import "../ownership/rbac/RBACWithAdmin.sol";
+import "../examples/RBACWithAdmin.sol";
 
 
 contract RBACMock is RBACWithAdmin {

--- a/contracts/ownership/rbac/RBACOwnable.sol
+++ b/contracts/ownership/rbac/RBACOwnable.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.18;
+
+import "./RBAC.sol";
+
+
+/**
+ * @title RBACOwnable
+ * @author Matt Condon (@shrugs)
+ * @dev RBACOwnable re-implements the Ownable API (sans public owner() getter) using
+ * @dev the RBAC library. Contracts inheriting from RBACOwnable can use
+ * #dev the RBAC library to implement additional roles as well.
+ */
+contract RBACOwnable is RBAC {
+  string public constant ROLE_OWNER = "owner";
+
+
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+
+  modifier onlyValidAddress(address _addr)
+  {
+    require(_addr != address(0));
+    _;
+  }
+
+  modifier onlyOwner()
+  {
+    checkRole(msg.sender, ROLE_OWNER);
+    _;
+  }
+
+  function RBACOwnable()
+    public
+  {
+    addRole(msg.sender, ROLE_OWNER);
+  }
+
+  function transferOwnership(address _owner)
+    onlyOwner
+    onlyValidAddress(_owner)
+    public
+  {
+    addRole(_owner, ROLE_OWNER);
+    removeRole(msg.sender, ROLE_OWNER);
+    OwnershipTransferred(msg.sender, _owner);
+  }
+}

--- a/test/ownership/Ownable.test.js
+++ b/test/ownership/Ownable.test.js
@@ -1,5 +1,6 @@
 
 import assertRevert from '../helpers/assertRevert';
+import expectEvent from '../helpers/expectEvent';
 
 var Ownable = artifacts.require('Ownable');
 
@@ -33,5 +34,13 @@ contract('Ownable', function (accounts) {
   it('should guard ownership against stuck state', async function () {
     let originalOwner = await ownable.owner();
     await assertRevert(ownable.transferOwnership(null, { from: originalOwner }));
+  });
+
+  it('should emit OwnershipTransferred', async () => {
+    const other = accounts[2];
+    await expectEvent.inTransaction(
+      ownable.transferOwnership(other),
+      'OwnershipTransferred'
+    );
   });
 });

--- a/test/ownership/rbac/RBACOwnable.test.js
+++ b/test/ownership/rbac/RBACOwnable.test.js
@@ -1,0 +1,51 @@
+import expectEvent from '../../helpers/expectEvent';
+import assertRevert from '../../helpers/assertRevert';
+const RBACOwnable = artifacts.require('RBACOwnable');
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should();
+
+contract('RBACOwnable', ([owner, newOwner, anyone]) => {
+  let ownable;
+  let role;
+
+  before(async () => {
+    ownable = await RBACOwnable.new({ from: owner });
+    role = await ownable.ROLE_OWNER();
+  });
+
+  it('should have a default owner of self', async () => {
+    const hasRole = await ownable.hasRole(owner, role);
+
+    hasRole.should.eq(true);
+  });
+
+  it('changes owner after transfer', async () => {
+    await ownable.transferOwnership(newOwner);
+    const hasRole = await ownable.hasRole(newOwner, role);
+    const ownerHasRole = await ownable.hasRole(owner, role);
+
+    hasRole.should.eq(true);
+    ownerHasRole.should.eq(false);
+  });
+
+  it('should prevent non-owners from transfering', async () => {
+    await assertRevert(
+      ownable.transferOwnership(owner, { from: anyone })
+    );
+  });
+
+  it('should guard ownership against stuck state', async () => {
+    await assertRevert(
+      ownable.transferOwnership(null, { from: newOwner })
+    );
+  });
+
+  it('should emit OwnershipTransferred', async () => {
+    await expectEvent.inTransaction(
+      ownable.transferOwnership(owner, { from: newOwner }),
+      'OwnershipTransferred'
+    );
+  });
+});


### PR DESCRIPTION
# 🚀 Description

Implement the `Ownable` API using RBAC
- excluding the `owner()` public getter because we're not saving that address in contract storage, only their permissions

### TODO

- [ ] rebase on #868 and add `emit` and update solidity pragma

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
