### PR TITLE
Add travis job to run test suite with solc nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ cache:
 env:
   -
   - SOLIDITY_COVERAGE=true
+  - SOLC_NIGHTLY=true
 matrix:
   fast_finish: true
   allow_failures:
     - env: SOLIDITY_COVERAGE=true
+    - env: SOLC_NIGHTLY=true
 before_script:
   - truffle version
 script:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -54,6 +54,11 @@ else
   start_ganache
 fi
 
+if [ "$SOLC_NIGHTLY" = true ]; then
+  echo "Downloading solc nightly"
+  wget -q https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-nightly.js -O /tmp/soljson.js && find . -name soljson.js -exec cp /tmp/soljson.js {} \;
+fi
+
 if [ "$SOLIDITY_COVERAGE" = true ]; then
   node_modules/.bin/solidity-coverage
 


### PR DESCRIPTION
The specific travis job is allowed to fail, and is run just for informational purposes. The goal is to keep both us and the solidity development team informed of compiler changes in the OpenZeppelin codebase (see [here](https://twitter.com/ethchris/status/984705626528993280) for more info).
