### PR TITLE
Fix ERC721 test is not checking name and symbol properly #910

### DIFF
--- a/test/token/ERC721/ERC721Token.test.js
+++ b/test/token/ERC721/ERC721Token.test.js
@@ -80,13 +80,13 @@ contract('ERC721Token', function (accounts) {
       const sampleUri = 'mock://mytoken';
 
       it('has a name', async function () {
-        const name = await this.token.name();
-        name.should.be.equal(name);
+        const tokenName = await this.token.name();
+        tokenName.should.be.equal(name);
       });
 
       it('has a symbol', async function () {
-        const symbol = await this.token.symbol();
-        symbol.should.be.equal(symbol);
+        const tokenSymbol = await this.token.symbol();
+        tokenSymbol.should.be.equal(symbol);
       });
 
       it('sets and returns metadata for a token id', async function () {


### PR DESCRIPTION
Fixes #910 

# 🚀 Description

Changed const name in ERC721 test.

- [x] 📘 I've reviewed the [OpenZeppelin Contributor Guidelines](../blob/master/CONTRIBUTING.md)
- [x] ✅ I've added tests where applicable to test my new functionality.
- [x] 📖 I've made sure that my contracts are well-documented.
- [x] 🎨 I've run the JS/Solidity linters and fixed any issues (`npm run lint:all:fix`).
